### PR TITLE
Feat: add Chip component

### DIFF
--- a/src/components/atoms/chip/Chip.tsx
+++ b/src/components/atoms/chip/Chip.tsx
@@ -1,0 +1,32 @@
+interface Props {
+  status: 'completed' | 'booked' | 'fixed' | 'remained';
+  count: number;
+}
+
+export default function Chip({ status, count }: Props) {
+  const statusStyle = {
+    completed: {
+      text: '완료',
+      style: 'bg-var-gray6 text-var-gray1',
+    },
+    booked: {
+      text: '예약',
+      style: 'bg-var-blue text-white',
+    },
+    fixed: {
+      text: '확정',
+      style: 'bg-var-orange text-var-orange-dark',
+    },
+    remained: {
+      text: '잔여',
+      style: 'bg-white text-var-blue',
+    },
+  };
+  return (
+    <div
+      className={`w-full rounded-[4px] px-4pxr py-3pxr text-12pxr md:text-14pxr ${statusStyle[status].style}`}
+    >
+      {statusStyle[status].text} {count}
+    </div>
+  );
+}


### PR DESCRIPTION
## 어떤 기능인가요?

달력에 사용하는 chip 컴포넌트 구현 

## 작업 상세 내용

- [x] /atoms/chip/Chip.tsx 개발

## 테스트 방법 (선택)

```javascript
<Chip status='completed' count={13} />
```

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="498" alt="스크린샷 2024-07-06 오전 11 35 43" src="https://github.com/part-4-team-3/glabal-nomad/assets/105799083/06b5d825-fe87-4ab1-b107-7ad98c5fe277">

## 고민되거나 어려운 부분 (선택)

저번 팀미팅 때 얘기 나왔던 cn()을 써보았는데, 누락 오류를 발견했습니다.

```javascript
// <div className={w-full rounded-[4px] px-4pxr py-3pxr text-14pxr ${statusStyle[status].style}}>

<div className={cn('w-full rounded-[4px] px-4pxr py-3pxr text-14pxr', statusStyle[status].style)}>
```

위 방식으로 적었더니 text-14pxr이 statusStyle[status].style에 들어있던 text-white에 의해 덮어씌워졌습니다.
챗지피티에게 물어보니 그냥 주석처리해둔 것처럼 작성하는 등의 해결책을 주더라구요.

`text-`라는 점이 같아서 덮어씌워진 것 같습니다.
다른 방안이 없다면 제 생각엔 cn을 쓰지 않아야 할 것 같습니다..!

이 부분 팀미팅 때 얘기해봐야할 것 같아요!
