### PR TITLE
Feat: edit Button component

### DIFF
--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -5,19 +5,19 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
   color: 'white' | 'black';
   size?: 's' | 'm' | 'l';
-  addStyle?: string;
   link?: string;
+  className?: string;
 }
 
 export default function Button({
   text,
   color,
   size,
-  addStyle = '',
   type,
   onClick,
   disabled,
   link,
+  className = '',
 }: Props) {
   let sizeStyle;
   switch (size) {
@@ -39,7 +39,7 @@ export default function Button({
     ? 'bg-var-gray3 border border-var-gray3 !text-white'
     : 'border border-var-green-dark2';
 
-  const style = `rounded-[6px] font-[700] ${colorStyle} ${sizeStyle} ${addStyle} ${disabledStyle}`;
+  const style = `rounded-[6px] font-[700] ${colorStyle} ${sizeStyle} ${className} ${disabledStyle}`;
 
   if (link)
     return (

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -3,12 +3,22 @@ import { ButtonHTMLAttributes } from 'react';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
-  size: 's' | 'm' | 'l';
   color: 'white' | 'black';
+  size?: 's' | 'm' | 'l';
+  addStyle?: string;
   link?: string;
 }
 
-export default function Button({ text, size, color, onClick, disabled, link }: Props) {
+export default function Button({
+  text,
+  color,
+  size,
+  addStyle = '',
+  type,
+  onClick,
+  disabled,
+  link,
+}: Props) {
   let sizeStyle;
   switch (size) {
     case 's':
@@ -18,15 +28,18 @@ export default function Button({ text, size, color, onClick, disabled, link }: P
       sizeStyle = 'px-33pxr py-16pxr text-16pxr';
       break;
     case 'l':
-      sizeStyle = 'py-14pxr w-full text-16pxr';
+      sizeStyle = 'w-full py-14pxr text-16pxr';
+      break;
+    default:
+      sizeStyle = '';
   }
   const colorStyle =
-    color === 'white' ? 'bg-white text-var-green-dark' : 'bg-var-green-dark text-white';
+    color === 'white' ? 'bg-white text-var-green-dark2' : 'bg-var-green-dark2 text-white';
   const disabledStyle = disabled
     ? 'bg-var-gray3 border border-var-gray3 !text-white'
-    : 'border border-var-green-dark';
+    : 'border border-var-green-dark2';
 
-  const style = `rounded-[6px] font-[700] ${sizeStyle} ${colorStyle} ${disabledStyle}`;
+  const style = `rounded-[6px] font-[700] ${colorStyle} ${sizeStyle} ${addStyle} ${disabledStyle}`;
 
   if (link)
     return (
@@ -36,7 +49,7 @@ export default function Button({ text, size, color, onClick, disabled, link }: P
     );
 
   return (
-    <button className={style} onClick={onClick} disabled={disabled}>
+    <button className={style} onClick={onClick} type={type} disabled={disabled}>
       {text}
     </button>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,7 @@ const config = {
         'var-gray8': '#FAFAFA',
         'var-green': '#00AC07',
         'var-green-dark': '#0B3B2D',
+        'var-green-dark2': '#112211',
         'var-green-light': '#F1EFFD',
         'var-red-dark': '#FF472E',
         'var-red-light': '#FFE4E0',


### PR DESCRIPTION
## 어떤 기능인가요?

피그마로 페이지에 쓰이는 버튼 컴포넌트들을 보니 
기존 s, m, l 사이즈보다 스타일이 더 다양해서 
className으로 추가 텍스트를 받아서 style 구현할 수 있도록 수정하였습니다.

## 작업 상세 내용

- [x] /atoms/button/Button.tsx 수정
- [x] /app/globals.css 커스텀색 추가

## 테스트 방법 (선택)

```javascript
// 기존 사이즈 쓸 경우
<Button text="로그인" color="white" size="l" onClick={handleClick} />
// 기존 스타일 외에 추가 style 적용할 경우
<Button text="로그인" color="white" onClick={handleClick} className="px-15pxr py-10pxr" />
```

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="176" alt="스크린샷 2024-07-08 오후 1 20 18" src="https://github.com/part-4-team-3/glabal-nomad/assets/105799083/92b48dfb-fe85-4655-bad4-89641e392764">

## 고민되거나 어려운 부분 (선택)

버튼 스타일이 많이 다양해서 특정할 수 없을 것 같습니다.
페이지에서 그 때 그 때 사용하려는 스타일을 className으로 추가해서 사용해주세욥!