### PR TITLE
feat: cookie 저장할 때 httpOnly:true 설정 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,9 @@
 import Header from '@/components/templates/header/Header';
 import Banner from '@/components/templates/main/Banner';
 import Main from '@/components/templates/main/Main';
+import { cookie } from '@/lib/cookie';
 import { getActivitiesQueryOptions } from '@/queries/activities/get-activities';
 import { useQuery } from '@tanstack/react-query';
-
 
 const USER = {
   id: 593,

--- a/src/lib/cookie.ts
+++ b/src/lib/cookie.ts
@@ -1,4 +1,4 @@
-import { Cookies } from "react-cookie";
+import { Cookies } from 'react-cookie';
 
 const cookies = new Cookies();
 
@@ -9,7 +9,7 @@ export const cookie = {
   },
 
   setCookie: (key: string, value: string) => {
-    cookies.set(key, value);
+    cookies.set(key, value, { httpOnly: true });
   },
 
   removeCookie: (key: string) => {


### PR DESCRIPTION
## 어떤 기능인가요?

cookie.setCookie로 cookie를 저장할 때 httpOnly:true 설정 추가함

## 작업 상세 내용

- [x] httpOnly:true 설정 추가

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="433" alt="스크린샷 2024-07-10 오전 11 51 09" src="https://github.com/part-4-team-3/glabal-nomad/assets/112109663/7547e6ac-6072-49e5-ad7c-740bf9736b18">

