### PR TITLE
Feat/activity reservation bar

### DIFF
--- a/public/x-icon.svg
+++ b/public/x-icon.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="btn_X_40px">
+<path id="Vector 663" d="M10 10L30 30" stroke="#4B4B4B" stroke-width="2.5" stroke-linecap="round"/>
+<path id="Vector 663_2" d="M30 10L10 30" stroke="#4B4B4B" stroke-width="2.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/app/(main)/activity/[id]/page.tsx
+++ b/src/app/(main)/activity/[id]/page.tsx
@@ -1,5 +1,10 @@
+'use client';
+
 import ImageCarousel from '@/components/molecules/image-carousel/ImageCarousel';
 import ActivityHeader from '@/components/organisms/activity-header/ActivityHeader';
+import ActivityReservationBar from '@/components/organisms/activity-reservation-bar/ActivityReservationBar';
+import { parseISO } from 'date-fns';
+import { createScheduleHashMap } from '@/models/activity-reservation/create-schedule-hash-map';
 
 interface Props {
   params: { id: number };
@@ -35,15 +40,21 @@ const mockData = {
   schedules: [
     {
       id: 1,
-      date: '2023-12-01',
+      date: '2024-07-07',
       startTime: '12:00',
       endTime: '13:00',
     },
     {
       id: 2,
-      date: '2023-12-05',
+      date: '2024-07-25',
       startTime: '12:00',
       endTime: '13:00',
+    },
+    {
+      id: 3,
+      date: '2024-07-25',
+      startTime: '14:00',
+      endTime: '15:00',
     },
   ],
   reviewCount: 5,
@@ -53,9 +64,12 @@ const mockData = {
 };
 
 export default function Page({ params }: Props) {
+  const scheduleHash = createScheduleHashMap(mockData.schedules);
+
+  const scheduledDates = mockData.schedules?.map((schedule) => parseISO(schedule.date));
+
   return (
     <main>
-      <div>{params.id}</div>
       <ActivityHeader
         category={mockData.category}
         title={mockData.title}
@@ -64,6 +78,12 @@ export default function Page({ params }: Props) {
         reviewCount={mockData.reviewCount}
       />
       <ImageCarousel bannerImg={mockData.bannerImageUrl} subImg={mockData.subImageUrls} />
+
+      <ActivityReservationBar
+        price={mockData.price}
+        scheduleHash={scheduleHash}
+        scheduledDates={scheduledDates}
+      />
     </main>
   );
 }

--- a/src/components/atoms/schedule-button/ScheduleButton.tsx
+++ b/src/components/atoms/schedule-button/ScheduleButton.tsx
@@ -1,0 +1,16 @@
+import { ButtonHTMLAttributes } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export default function ScheduleButton({ children, ...rest }: Props) {
+  return (
+    <button
+      {...rest}
+      className="rounded-[8px] border border-var-green-dark px-12pxr py-10pxr font-[500] text-var-green-dark focus:bg-var-green-dark focus:text-white"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
+++ b/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
@@ -1,38 +1,60 @@
 'use client';
 
-import * as React from 'react';
 import { format } from 'date-fns';
 import { Calendar } from '@/components/ui/calendar';
-
-type schedule = {
-  id: number;
-  date: string;
-  startTime: '12:00';
-  endTime: '13:00';
-};
+import { Schedule } from '@/types/schedule';
+import { parseISO } from 'date-fns';
+import {
+  createScheduleHashMap,
+  ScheduleHashMap,
+} from '@/models/activity-reservation/create-schedule-hash-map';
+import ScheduleButton from '@/components/atoms/schedule-button/ScheduleButton';
+import { useState } from 'react';
 
 interface Props {
-  scheduled?: Date[];
+  schedules?: Schedule[];
+  scheduledDates: Date[];
+  scheduleHash: ScheduleHashMap;
 }
 
-export function ActivityCalendar({ scheduled }: Props) {
-  const [date, setDate] = React.useState<Date | undefined>(new Date());
+export function ActivityReservationSelector({
+  schedules = [],
+  scheduledDates,
+  scheduleHash,
+}: Props) {
+  const [date, setDate] = useState<Date | undefined>(undefined);
+  const [selectedSchedule, setSelectedSchedule] = useState<Schedule | undefined>();
 
   const formattedDate = date ? format(date, 'yyyy-MM-dd') : '';
 
+  const message = date ? '해당 날짜에 가능한 스케줄이 없습니다' : '날짜를 선택해주세요';
+
   return (
-    <div>
-      <h2>날짜</h2>
+    <div className="flex w-fit flex-col gap-24pxr px-24pxr py-32pxr">
+      <h2 className="text-28pxr font-[700]">날짜</h2>
       <Calendar
         mode="single"
-        scheduled={scheduled}
+        scheduled={scheduledDates}
         selected={date}
         onSelect={setDate}
         className="w-fit rounded-md border shadow"
       />
-      {date && <p>{formattedDate}</p>}
 
       <p className="text-18pxr font-[700]">예약 가능한 시간</p>
+      {formattedDate != '' && scheduleHash[formattedDate] ? (
+        <div className="flex gap-12pxr">
+          {scheduleHash[formattedDate].map((schedule) => (
+            <ScheduleButton
+              key={schedule.id}
+              onClick={() => setSelectedSchedule({ ...schedule, date: formattedDate })}
+            >
+              {schedule.startTime}~{schedule.endTime}
+            </ScheduleButton>
+          ))}
+        </div>
+      ) : (
+        <p className="w-full text-center">{message}</p>
+      )}
     </div>
   );
 }

--- a/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
+++ b/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
@@ -3,7 +3,7 @@
 import { format } from 'date-fns';
 import { Calendar } from '@/components/ui/calendar';
 import { Schedule } from '@/types/schedule';
-import { parseISO } from 'date-fns';
+import Image from 'next/image';
 import {
   createScheduleHashMap,
   ScheduleHashMap,
@@ -30,31 +30,41 @@ export function ActivityReservationSelector({
   const message = date ? '해당 날짜에 가능한 스케줄이 없습니다' : '날짜를 선택해주세요';
 
   return (
-    <div className="flex w-fit flex-col gap-24pxr px-24pxr py-32pxr">
-      <h2 className="text-28pxr font-[700]">날짜</h2>
-      <Calendar
-        mode="single"
-        scheduled={scheduledDates}
-        selected={date}
-        onSelect={setDate}
-        className="w-fit rounded-md border shadow"
-      />
-
-      <p className="text-18pxr font-[700]">예약 가능한 시간</p>
-      {formattedDate != '' && scheduleHash[formattedDate] ? (
-        <div className="flex gap-12pxr">
-          {scheduleHash[formattedDate].map((schedule) => (
-            <ScheduleButton
-              key={schedule.id}
-              onClick={() => setSelectedSchedule({ ...schedule, date: formattedDate })}
-            >
-              {schedule.startTime}~{schedule.endTime}
-            </ScheduleButton>
-          ))}
+    <div className="fixed left-[0px] right-[0px] top-[0px] z-10 h-screen w-screen bg-white px-24pxr py-32pxr">
+      <div className="flex w-full flex-col gap-24pxr">
+        <div className="flex w-full items-center justify-between">
+          {' '}
+          <h2 className="text-28pxr font-[700]">날짜</h2>
+          <button className="rounded-full hover:bg-var-gray6">
+            <Image src="/x-icon.svg" width={40} height={40} alt="close" />
+          </button>
         </div>
-      ) : (
-        <p className="w-full text-center">{message}</p>
-      )}
+        <div className="flex justify-center">
+          <Calendar
+            mode="single"
+            scheduled={scheduledDates}
+            selected={date}
+            onSelect={setDate}
+            className="w-fit rounded-md border shadow"
+          />
+        </div>
+
+        <p className="text-18pxr font-[700]">예약 가능한 시간</p>
+        {formattedDate != '' && scheduleHash[formattedDate] ? (
+          <div className="flex gap-12pxr">
+            {scheduleHash[formattedDate].map((schedule) => (
+              <ScheduleButton
+                key={schedule.id}
+                onClick={() => setSelectedSchedule({ ...schedule, date: formattedDate })}
+              >
+                {schedule.startTime}~{schedule.endTime}
+              </ScheduleButton>
+            ))}
+          </div>
+        ) : (
+          <p className="w-full text-center">{message}</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
+++ b/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
@@ -4,25 +4,24 @@ import { format } from 'date-fns';
 import { Calendar } from '@/components/ui/calendar';
 import { Schedule } from '@/types/schedule';
 import Image from 'next/image';
-import {
-  createScheduleHashMap,
-  ScheduleHashMap,
-} from '@/models/activity-reservation/create-schedule-hash-map';
+import { ScheduleHashMap } from '@/models/activity-reservation/create-schedule-hash-map';
 import ScheduleButton from '@/components/atoms/schedule-button/ScheduleButton';
 import { useState } from 'react';
+import Button from '@/components/atoms/button/Button';
 
 interface Props {
   schedules?: Schedule[];
   scheduledDates: Date[];
   scheduleHash: ScheduleHashMap;
   onClose: () => void;
+  onSelect: (schedule: Schedule | undefined) => void;
 }
 
 export function ActivityReservationSelector({
-  schedules = [],
   scheduledDates,
   scheduleHash,
   onClose,
+  onSelect,
 }: Props) {
   const [date, setDate] = useState<Date | undefined>(undefined);
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | undefined>();
@@ -31,8 +30,13 @@ export function ActivityReservationSelector({
 
   const message = date ? '해당 날짜에 가능한 스케줄이 없습니다' : '날짜를 선택해주세요';
 
+  const handleAccept = () => {
+    onSelect(selectedSchedule);
+    onClose();
+  };
+
   return (
-    <div className="fixed left-[0px] right-[0px] top-[0px] z-10 h-screen w-screen bg-white px-24pxr py-32pxr">
+    <div className="fixed left-[0px] right-[0px] top-[0px] z-10 flex h-screen w-screen flex-col justify-between bg-white px-24pxr py-32pxr">
       <div className="flex w-full flex-col gap-24pxr">
         <div className="flex w-full items-center justify-between">
           {' '}
@@ -67,6 +71,13 @@ export function ActivityReservationSelector({
           <p className="w-full text-center">{message}</p>
         )}
       </div>
+      <Button
+        text="확인"
+        color="black"
+        onClick={handleAccept}
+        disabled={!selectedSchedule}
+        className="py-15pxr"
+      />
     </div>
   );
 }

--- a/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
+++ b/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import * as React from 'react';
+import { format } from 'date-fns';
+import { Calendar } from '@/components/ui/calendar';
+
+type schedule = {
+  id: number;
+  date: string;
+  startTime: '12:00';
+  endTime: '13:00';
+};
+
+interface Props {
+  scheduled?: Date[];
+}
+
+export function ActivityCalendar({ scheduled }: Props) {
+  const [date, setDate] = React.useState<Date | undefined>(new Date());
+
+  const formattedDate = date ? format(date, 'yyyy-MM-dd') : '';
+
+  return (
+    <div>
+      <h2>날짜</h2>
+      <Calendar
+        mode="single"
+        scheduled={scheduled}
+        selected={date}
+        onSelect={setDate}
+        className="w-fit rounded-md border shadow"
+      />
+      {date && <p>{formattedDate}</p>}
+
+      <p className="text-18pxr font-[700]">예약 가능한 시간</p>
+    </div>
+  );
+}

--- a/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
+++ b/src/components/molecules/activity-reservation-selector/ActivityReservationSelector.tsx
@@ -15,12 +15,14 @@ interface Props {
   schedules?: Schedule[];
   scheduledDates: Date[];
   scheduleHash: ScheduleHashMap;
+  onClose: () => void;
 }
 
 export function ActivityReservationSelector({
   schedules = [],
   scheduledDates,
   scheduleHash,
+  onClose,
 }: Props) {
   const [date, setDate] = useState<Date | undefined>(undefined);
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | undefined>();
@@ -35,7 +37,7 @@ export function ActivityReservationSelector({
         <div className="flex w-full items-center justify-between">
           {' '}
           <h2 className="text-28pxr font-[700]">날짜</h2>
-          <button className="rounded-full hover:bg-var-gray6">
+          <button className="rounded-full hover:bg-var-gray6" onClick={onClose}>
             <Image src="/x-icon.svg" width={40} height={40} alt="close" />
           </button>
         </div>

--- a/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
+++ b/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
@@ -14,8 +14,8 @@ interface Props {
 }
 
 export default function ActivityReservationBar({ price, scheduleHash, scheduledDates }: Props) {
-  const [isScheduleSelectorOpen, setIsScheduleSelectorOpon] = useState<boolean>(false);
-  const [isNumberSelectorOpen, setIsNumberSelectorOpon] = useState<boolean>(false);
+  const [isScheduleSelectorOpen, setIsScheduleSelectorOpen] = useState<boolean>(false);
+  const [isNumberSelectorOpen, setIsNumberSelectorOpen] = useState<boolean>(false);
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | undefined>();
 
   const dateButtonText = selectedSchedule
@@ -32,7 +32,7 @@ export default function ActivityReservationBar({ price, scheduleHash, scheduledD
         </div>
         <button
           className="w-fit text-14pxr font-[600] text-var-green-dark underline"
-          onClick={() => setIsScheduleSelectorOpon(true)}
+          onClick={() => setIsScheduleSelectorOpen(true)}
         >
           {dateButtonText}
         </button>
@@ -49,7 +49,7 @@ export default function ActivityReservationBar({ price, scheduleHash, scheduledD
         <ActivityReservationSelector
           scheduleHash={scheduleHash}
           scheduledDates={scheduledDates}
-          onClose={() => setIsScheduleSelectorOpon(false)}
+          onClose={() => setIsScheduleSelectorOpen(false)}
           onSelect={(schedule: Schedule | undefined) => setSelectedSchedule(schedule)}
         />
       )}

--- a/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
+++ b/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import Button from '@/components/atoms/button/Button';
 import { ScheduleHashMap } from '@/models/activity-reservation/create-schedule-hash-map';
 import { ActivityReservationSelector } from '@/components/molecules/activity-reservation-selector/ActivityReservationSelector';
+import { Schedule } from '@/types/schedule';
+import { format } from 'date-fns';
 
 interface Props {
   price: number;
@@ -14,6 +16,11 @@ interface Props {
 export default function ActivityReservationBar({ price, scheduleHash, scheduledDates }: Props) {
   const [isScheduleSelectorOpen, setIsScheduleSelectorOpon] = useState<boolean>(false);
   const [isNumberSelectorOpen, setIsNumberSelectorOpon] = useState<boolean>(false);
+  const [selectedSchedule, setSelectedSchedule] = useState<Schedule | undefined>();
+
+  const dateButtonText = selectedSchedule
+    ? `${format(selectedSchedule.date, 'yy/MM/dd')} ${selectedSchedule.startTime} ~ ${selectedSchedule.endTime}`
+    : '날짜 선택하기';
 
   return (
     <div className="fixed bottom-[0px] left-[0px] right-[0px] flex w-full justify-between border-t border-[#a1a1a1] p-[16px]">
@@ -27,7 +34,7 @@ export default function ActivityReservationBar({ price, scheduleHash, scheduledD
           className="w-fit text-14pxr font-[600] text-var-green-dark underline"
           onClick={() => setIsScheduleSelectorOpon(true)}
         >
-          날짜 선택하기
+          {dateButtonText}
         </button>
       </div>
 
@@ -35,7 +42,7 @@ export default function ActivityReservationBar({ price, scheduleHash, scheduledD
         text="예약하기"
         color="black"
         className="px-24pxr py-14pxr disabled:bg-var-gray3"
-        disabled={true}
+        disabled={!selectedSchedule}
       ></Button>
 
       {isScheduleSelectorOpen && (
@@ -43,6 +50,7 @@ export default function ActivityReservationBar({ price, scheduleHash, scheduledD
           scheduleHash={scheduleHash}
           scheduledDates={scheduledDates}
           onClose={() => setIsScheduleSelectorOpon(false)}
+          onSelect={(schedule: Schedule | undefined) => setSelectedSchedule(schedule)}
         />
       )}
     </div>

--- a/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
+++ b/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Button from '@/components/atoms/button/Button';
 import { ScheduleHashMap } from '@/models/activity-reservation/create-schedule-hash-map';
+import { ActivityReservationSelector } from '@/components/molecules/activity-reservation-selector/ActivityReservationSelector';
 
 interface Props {
   price: number;
@@ -10,7 +11,7 @@ interface Props {
   scheduleHash: ScheduleHashMap;
 }
 
-export default function ActivityReservationBar({ price }: Props) {
+export default function ActivityReservationBar({ price, scheduleHash, scheduledDates }: Props) {
   const [isScheduleSelectorOpen, setIsScheduleSelectorOpon] = useState<boolean>(false);
   const [isNumberSelectorOpen, setIsNumberSelectorOpon] = useState<boolean>(false);
 
@@ -22,7 +23,10 @@ export default function ActivityReservationBar({ price }: Props) {
           <span>/</span>
           <button className="text-18pxr text-var-green-dark underline">1명</button>
         </div>
-        <button className="w-fit text-14pxr font-[600] text-var-green-dark underline">
+        <button
+          className="w-fit text-14pxr font-[600] text-var-green-dark underline"
+          onClick={() => setIsScheduleSelectorOpon(true)}
+        >
           날짜 선택하기
         </button>
       </div>
@@ -33,6 +37,14 @@ export default function ActivityReservationBar({ price }: Props) {
         className="px-24pxr py-14pxr disabled:bg-var-gray3"
         disabled={true}
       ></Button>
+
+      {isScheduleSelectorOpen && (
+        <ActivityReservationSelector
+          scheduleHash={scheduleHash}
+          scheduledDates={scheduledDates}
+          onClose={() => setIsScheduleSelectorOpon(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
+++ b/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import Button from '@/components/atoms/button/Button';
+import { ScheduleHashMap } from '@/models/activity-reservation/create-schedule-hash-map';
+
+interface Props {
+  price: number;
+  scheduledDates: Date[];
+  scheduleHash: ScheduleHashMap;
+}
+
+export default function ActivityReservationBar({ price }: Props) {
+  const [isScheduleSelectorOpen, setIsScheduleSelectorOpon] = useState<boolean>(false);
+  const [isNumberSelectorOpen, setIsNumberSelectorOpon] = useState<boolean>(false);
+
+  return (
+    <div className="fixed bottom-[0px] left-[0px] right-[0px] flex w-full justify-between border-t border-[#a1a1a1] p-[16px]">
+      <div className="flex flex-col gap-8pxr">
+        <div className="flex gap-6pxr text-20pxr font-[700] leading-[26px]">
+          <span>₩{price}</span>
+          <span>/</span>
+          <button className="text-18pxr text-var-green-dark underline">1명</button>
+        </div>
+        <button className="w-fit text-14pxr font-[600] text-var-green-dark underline">
+          날짜 선택하기
+        </button>
+      </div>
+
+      <Button
+        text="예약하기"
+        color="black"
+        className="px-24pxr py-14pxr disabled:bg-var-gray3"
+        disabled={true}
+      ></Button>
+    </div>
+  );
+}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -3,60 +3,77 @@
 import * as React from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { DayPicker, DateFormatter } from 'react-day-picker';
-import { format } from 'date-fns';
+import { format, isSameDay } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 
 import { cn } from '@/lib/tailwind-utils';
 import { buttonVariants } from '@/components/ui/button';
 
-export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+export type CalendarProps = React.ComponentProps<typeof DayPicker> & { scheduled?: Date[] };
 
-function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
-  const dayFormatter: DateFormatter = (date, options) => format(date, 'eee', { locale: enUS });
+function Calendar({
+  className,
+  classNames,
+  scheduled = [],
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  const dayFormatter: DateFormatter = (date) => format(date, 'eee', { locale: enUS });
+
+  // Matcher function to check if the date is in the scheduled dates
+  const isScheduled = (date: Date) =>
+    scheduled.some((scheduledDate) => isSameDay(scheduledDate, date));
 
   return (
-    <DayPicker
-      showOutsideDays={showOutsideDays}
-      formatters={{ formatWeekdayName: dayFormatter }}
-      className={cn('p-[12px]', className)}
-      classNames={{
-        months: 'flex flex-col sm:flex-row space-y-[16px] sm:space-x-[16px] sm:space-y-0',
-        month: 'space-y-[16px]',
-        caption: 'flex justify-center pt-[4px] relative items-center',
-        caption_label: 'text-sm font-medium',
-        nav: 'space-x-[4px] flex items-center',
-        nav_button: cn(
-          buttonVariants({ variant: 'outline' }),
-          'h-[28px] w-[28px] bg-transparent p-0 opacity-50 hover:opacity-100',
-        ),
-        nav_button_previous: 'absolute left-[4px]',
-        nav_button_next: 'absolute right-[4px]',
-        table: 'w-full border-collapse space-y-[4px]',
-        head_row: 'flex',
-        head_cell: 'text-muted-foreground rounded-md w-[36px] font-normal text-[0.8rem]',
-        row: 'flex w-full mt-[8px]',
-        cell: 'h-[36px] w-[36px] text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
-        day: cn(
-          buttonVariants({ variant: 'ghost' }),
-          'h-[36px] w-[36px] p-0 font-normal aria-selected:opacity-100',
-        ),
-        day_range_end: 'day-range-end',
-        day_selected:
-          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
-        day_today: 'bg-accent text-accent-foreground',
-        day_outside:
-          'day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30',
-        day_disabled: 'text-muted-foreground opacity-50',
-        day_range_middle: 'aria-selected:bg-accent aria-selected:text-accent-foreground',
-        day_hidden: 'invisible',
-        ...classNames,
-      }}
-      components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-[16px] w-[16px]" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-[16px] w-[16px]" />,
-      }}
-      {...props}
-    />
+    <div>
+      <p>{JSON.stringify(scheduled)}</p>
+      <DayPicker
+        showOutsideDays={showOutsideDays}
+        formatters={{ formatWeekdayName: dayFormatter }}
+        className={cn('p-[12px]', className)}
+        classNames={{
+          months: 'flex flex-col sm:flex-row space-y-[16px] sm:space-x-[16px] sm:space-y-0',
+          month: 'space-y-[16px]',
+          caption: 'flex justify-center pt-[4px] relative items-center',
+          caption_label: 'text-sm font-medium',
+          nav: 'space-x-[4px] flex items-center',
+          nav_button: cn(
+            buttonVariants({ variant: 'outline' }),
+            'h-[28px] w-[28px] bg-transparent p-0 opacity-50 hover:opacity-100',
+          ),
+          nav_button_previous: 'absolute left-[4px]',
+          nav_button_next: 'absolute right-[4px]',
+          table: 'w-full border-collapse space-y-[4px]',
+          head_row: 'flex',
+          head_cell: 'text-muted-foreground rounded-md w-[36px] font-normal text-[0.8rem]',
+          row: 'flex w-full mt-[8px]',
+          cell: 'h-[36px] w-[36px] text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
+          day: cn(
+            buttonVariants({ variant: 'ghost' }),
+            'h-[36px] w-[36px] p-0 font-normal aria-selected:opacity-100',
+          ),
+          day_range_end: 'day-range-end',
+          day_selected:
+            'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+          day_today: 'bg-accent text-accent-foreground',
+          day_outside:
+            'day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30',
+          day_disabled: 'text-muted-foreground opacity-50',
+          day_range_middle: 'aria-selected:bg-accent aria-selected:text-accent-foreground',
+          day_hidden: 'invisible',
+          ...classNames,
+        }}
+        modifiersClassNames={{
+          scheduled: 'bg-var-blue text-white',
+        }}
+        modifiers={{ scheduled: isScheduled }}
+        components={{
+          IconLeft: ({ ...props }) => <ChevronLeft className="h-[16px] w-[16px]" />,
+          IconRight: ({ ...props }) => <ChevronRight className="h-[16px] w-[16px]" />,
+        }}
+        {...props}
+      />
+    </div>
   );
 }
 Calendar.displayName = 'Calendar';

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -26,7 +26,6 @@ function Calendar({
 
   return (
     <div>
-      <p>{JSON.stringify(scheduled)}</p>
       <DayPicker
         showOutsideDays={showOutsideDays}
         formatters={{ formatWeekdayName: dayFormatter }}
@@ -54,7 +53,7 @@ function Calendar({
           ),
           day_range_end: 'day-range-end',
           day_selected:
-            'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+            'bg-var-green-dark text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-var-green-dark focus:text-primary-foreground',
           day_today: 'bg-accent text-accent-foreground',
           day_outside:
             'day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30',
@@ -64,7 +63,7 @@ function Calendar({
           ...classNames,
         }}
         modifiersClassNames={{
-          scheduled: 'bg-var-blue text-white',
+          scheduled: 'bg-var-green2 text-var-green-dark',
         }}
         modifiers={{ scheduled: isScheduled }}
         components={{

--- a/src/models/activity-reservation/create-schedule-hash-map.ts
+++ b/src/models/activity-reservation/create-schedule-hash-map.ts
@@ -1,0 +1,16 @@
+import { Schedule } from '@/types/schedule';
+
+type ScheduleHashMap = {
+  [key: string]: { startTime: string; endTime: string; id: number }[];
+};
+
+export function createScheduleHashMap(schedules: Schedule[]): ScheduleHashMap {
+  return schedules.reduce((acc: ScheduleHashMap, schedule: Schedule) => {
+    const { date, startTime, endTime, id } = schedule;
+    if (!acc[date]) {
+      acc[date] = [];
+    }
+    acc[date].push({ startTime, endTime, id });
+    return acc;
+  }, {});
+}

--- a/src/models/activity-reservation/create-schedule-hash-map.ts
+++ b/src/models/activity-reservation/create-schedule-hash-map.ts
@@ -1,6 +1,6 @@
 import { Schedule } from '@/types/schedule';
 
-type ScheduleHashMap = {
+export type ScheduleHashMap = {
   [key: string]: { startTime: string; endTime: string; id: number }[];
 };
 

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,6 @@
+export type Schedule = {
+  id: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+};


### PR DESCRIPTION
## 어떤 기능인가요?

모바일에서 체험 상세페이지 조회시 하단에 고정된 예약바 생성

## 작업 상세 내용

- 스케줄된 날짜 표시기능 추가
- 선택된 날짜 포매팅
- 날짜 선택창 열고 닫기 기능
- 날짜 선택시 스테이트 업데이트

## 테스트 방법 (선택)
/activity/[id] 페이지에 현재 임시로 띄워놨습니다

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)
![캡처](https://github.com/part-4-team-3/glabal-nomad/assets/77979028/18c0e9bd-730f-49a9-9268-ccafe7efb0e0)

![prdyd](https://github.com/part-4-team-3/glabal-nomad/assets/77979028/9933bc09-daae-4a3a-82ce-a44e1fc37c48)


## 고민되거나 어려운
컴포넌트 폴더 위치랑 코드 분리가 생각보다 잘 안되네요
> 이거 중점으로 봐주세요 👀
