### PR TITLE
feat: 내 체험 월별 예약 현황 조회 API react-query 개발

### DIFF
--- a/src/queries/myActivities/get-activities-month.ts
+++ b/src/queries/myActivities/get-activities-month.ts
@@ -1,0 +1,18 @@
+import { UseQueryOptions } from '@tanstack/react-query';
+import { myActivitiesKeys } from './query-keys';
+import { apiInstance } from '@/lib/axios';
+import { MyActivitiesOfMonth } from '@/types/activity';
+
+export const getMyActivitiesByMonth = {
+  queryOptions: (
+    data: { activityId: number; year: string; month: string },
+    enabled?: boolean,
+  ): UseQueryOptions<MyActivitiesOfMonth, Error> => ({
+    queryKey: myActivitiesKeys.getMyActivities(data.activityId),
+    queryFn: (): Promise<MyActivitiesOfMonth> =>
+      apiInstance.get<any, MyActivitiesOfMonth>(
+        `my-activities/${data.activityId}/reservation-dashboard?year=${data.year}&month=${data.month}`,
+      ),
+    enabled: enabled ?? !!data.activityId,
+  }),
+};

--- a/src/queries/myActivities/get-activities-month.ts
+++ b/src/queries/myActivities/get-activities-month.ts
@@ -8,7 +8,7 @@ export const getMyActivitiesByMonth = {
     data: { activityId: number; year: string; month: string },
     enabled?: boolean,
   ): UseQueryOptions<MyActivitiesOfMonth, Error> => ({
-    queryKey: myActivitiesKeys.getMyActivities(data.activityId),
+    queryKey: myActivitiesKeys.getMyActivitiesByMonth(data.activityId),
     queryFn: (): Promise<MyActivitiesOfMonth> =>
       apiInstance.get<any, MyActivitiesOfMonth>(
         `my-activities/${data.activityId}/reservation-dashboard?year=${data.year}&month=${data.month}`,

--- a/src/queries/myActivities/get-myactivities.ts
+++ b/src/queries/myActivities/get-myactivities.ts
@@ -1,0 +1,24 @@
+import { MyActivityList } from '@/types/activity';
+import { queryOptions, UseQueryOptions } from '@tanstack/react-query';
+import { myActivitiesKeys } from './query-keys';
+import { apiInstance } from '@/lib/axios';
+
+export const getMyActivityList = {
+  queryOptions: (
+    data: {
+      size: number;
+      cursorId: number | null;
+    },
+    enabled?: boolean,
+  ): UseQueryOptions<MyActivityList, Error> => ({
+    queryKey: myActivitiesKeys.getMyActivities(data?.cursorId, data.size),
+
+    queryFn: (): Promise<MyActivityList> => {
+      const url = data.cursorId
+        ? `my-activities?size=${data.size}&cursorId=${data.cursorId}`
+        : `my-activities?size=${data.size}`;
+      return apiInstance.get<any, MyActivityList>(url);
+    },
+    enabled: enabled ?? (!!data.cursorId && !!data.size),
+  }),
+};

--- a/src/queries/myActivities/query-keys.ts
+++ b/src/queries/myActivities/query-keys.ts
@@ -1,0 +1,3 @@
+export const myActivitiesKeys = {
+  getMyActivities: (activityId: number) => ['my-activities', activityId, 'reservation-dashboard'],
+};

--- a/src/queries/myActivities/query-keys.ts
+++ b/src/queries/myActivities/query-keys.ts
@@ -1,3 +1,8 @@
 export const myActivitiesKeys = {
-  getMyActivities: (activityId: number) => ['my-activities', activityId, 'reservation-dashboard'],
+  getMyActivitiesByMonth: (activityId: number) => [
+    'my-activities',
+    activityId,
+    'reservation-dashboard',
+  ],
+  getMyActivities: (cursorId: number | null, size: number) => ['my-activities', cursorId, size],
 };

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -12,3 +12,12 @@ export interface Activity {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface MyActivitiesOfMonth {
+  date: string;
+  reservations: {
+    completed: number;
+    confirmed: number;
+    pending: number;
+  };
+}

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -21,3 +21,9 @@ export interface MyActivitiesOfMonth {
     pending: number;
   };
 }
+
+export interface MyActivityList {
+  cursorId: number;
+  totalCount: number;
+  activities: Activity[];
+}


### PR DESCRIPTION
## 어떤 기능인가요?

내 체험 월별 예약 현황 조회 API react-query 개발

## 작업 상세 내용

- [x] myActivityKeys 추가 (react-query-key)
- [x] types/activity에 MyActivitiesOfMonth interface 추가
- [x] 내 체험 월별 예약 현황 조회 API react-query 추가
- [x] 내 체험 리스트 조회 API react-query 추가
- [x] 내 체험 리스트 조회 react-query-key 추가
- [x] types/activity에 MyActivityList interface 추가   
