### PR TITLE
Feat/review pagination

### DIFF
--- a/src/app/(main)/activity/[id]/page.tsx
+++ b/src/app/(main)/activity/[id]/page.tsx
@@ -1,13 +1,17 @@
-'use client';
-
 import ImageCarousel from '@/components/molecules/image-carousel/ImageCarousel';
 import ActivityHeader from '@/components/organisms/activity-header/ActivityHeader';
 import ActivityReservationBar from '@/components/organisms/activity-reservation-bar/ActivityReservationBar';
 import { parseISO } from 'date-fns';
 import { createScheduleHashMap } from '@/models/activity-reservation/create-schedule-hash-map';
-
+import { getActivityDetails } from '@/queries/activities/get-activity-details';
+import ParticipantCounter from '@/components/molecules/participant-counter/ParticipantCounter';
+import ReviewCard from '@/components/molecules/review-card/ReviewCard';
+import ReviewList from '@/components/organisms/review-list/ReviewList';
+import ReviewPagination from '@/components/templates/review-template/ReviewTemplate';
+import ReviewTemplate from '@/components/templates/review-template/ReviewTemplate';
 interface Props {
   params: { id: number };
+  searchParams: { [key: string]: string | string[] | undefined };
 }
 
 const mockData = {
@@ -63,10 +67,92 @@ const mockData = {
   updatedAt: '2023-12-31T21:28:50.589Z',
 };
 
-export default function Page({ params }: Props) {
+const mockRevs = [
+  {
+    id: 1234,
+    user: {
+      profileImageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/5-3_585_1720404945231.jpeg',
+      nickname: '죄송합니다 열심히 할게요',
+      id: 2222,
+    },
+    activityId: 12323,
+    rating: 4.9,
+    content:
+      '저는 저희 스트릿 댄서 체험에 참가하게 된 지 얼마 안됐지만, 정말 즐거운 시간을 보냈습니다. 새로운 스타일과 춤추기를 좋아하는 나에게 정말 적합한 체험이었고, 전문가가 직접 강사로 참여하기 때문에 어떤 수준의 춤추는 사람도 쉽게 이해할 수 있었습니다. 강사님께서 정말 친절하게 설명해주셔서 정말 좋았고, 이번 체험을 거쳐 새로운 스타일과 춤추기에 대한 열정이 더욱 생겼습니다. 저는 이 체험을 적극 추천합니다!',
+    createdAt: '2023-12-31T21:28:50.589Z',
+    updatedAt: '2023-12-31T21:28:50.589Z',
+  },
+  {
+    id: 1235,
+    user: {
+      profileImageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/5-3_585_1720404945231.jpeg',
+      nickname: '죄송합니다 열심히 할게요',
+      id: 2222,
+    },
+    activityId: 12323,
+    rating: 4.9,
+    content:
+      '저는 저희 스트릿 댄서 체험에 참가하게 된 지 얼마 안됐지만, 정말 즐거운 시간을 보냈습니다. 새로운 스타일과 춤추기를 좋아하는 나에게 정말 적합한 체험이었고, 전문가가 직접 강사로 참여하기 때문에 어떤 수준의 춤추는 사람도 쉽게 이해할 수 있었습니다. 강사님께서 정말 친절하게 설명해주셔서 정말 좋았고, 이번 체험을 거쳐 새로운 스타일과 춤추기에 대한 열정이 더욱 생겼습니다. 저는 이 체험을 적극 추천합니다!',
+    createdAt: '2023-12-31T21:28:50.589Z',
+    updatedAt: '2023-12-31T21:28:50.589Z',
+  },
+  {
+    id: 1236,
+    user: {
+      profileImageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/5-3_585_1720404945231.jpeg',
+      nickname: '죄송합니다 열심히 할게요',
+      id: 2222,
+    },
+    activityId: 12323,
+    rating: 4.9,
+    content:
+      '저는 저희 스트릿 댄서 체험에 참가하게 된 지 얼마 안됐지만, 정말 즐거운 시간을 보냈습니다. 새로운 스타일과 춤추기를 좋아하는 나에게 정말 적합한 체험이었고, 전문가가 직접 강사로 참여하기 때문에 어떤 수준의 춤추는 사람도 쉽게 이해할 수 있었습니다. 강사님께서 정말 친절하게 설명해주셔서 정말 좋았고, 이번 체험을 거쳐 새로운 스타일과 춤추기에 대한 열정이 더욱 생겼습니다. 저는 이 체험을 적극 추천합니다!',
+    createdAt: '2023-12-31T21:28:50.589Z',
+    updatedAt: '2023-12-31T21:28:50.589Z',
+  },
+  {
+    id: 1237,
+    user: {
+      profileImageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/5-3_585_1720404945231.jpeg',
+      nickname: '죄송합니다 열심히 할게요',
+      id: 2222,
+    },
+    activityId: 12323,
+    rating: 4.9,
+    content:
+      '저는 저희 스트릿 댄서 체험에 참가하게 된 지 얼마 안됐지만, 정말 즐거운 시간을 보냈습니다. 새로운 스타일과 춤추기를 좋아하는 나에게 정말 적합한 체험이었고, 전문가가 직접 강사로 참여하기 때문에 어떤 수준의 춤추는 사람도 쉽게 이해할 수 있었습니다. 강사님께서 정말 친절하게 설명해주셔서 정말 좋았고, 이번 체험을 거쳐 새로운 스타일과 춤추기에 대한 열정이 더욱 생겼습니다. 저는 이 체험을 적극 추천합니다!',
+    createdAt: '2023-12-31T21:28:50.589Z',
+    updatedAt: '2023-12-31T21:28:50.589Z',
+  },
+  {
+    id: 1238,
+    user: {
+      profileImageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/5-3_585_1720404945231.jpeg',
+      nickname: '죄송합니다 열심히 할게요',
+      id: 2222,
+    },
+    activityId: 12323,
+    rating: 4.9,
+    content:
+      '저는 저희 스트릿 댄서 체험에 참가하게 된 지 얼마 안됐지만, 정말 즐거운 시간을 보냈습니다. 새로운 스타일과 춤추기를 좋아하는 나에게 정말 적합한 체험이었고, 전문가가 직접 강사로 참여하기 때문에 어떤 수준의 춤추는 사람도 쉽게 이해할 수 있었습니다. 강사님께서 정말 친절하게 설명해주셔서 정말 좋았고, 이번 체험을 거쳐 새로운 스타일과 춤추기에 대한 열정이 더욱 생겼습니다. 저는 이 체험을 적극 추천합니다!',
+    createdAt: '2023-12-31T21:28:50.589Z',
+    updatedAt: '2023-12-31T21:28:50.589Z',
+  },
+];
+
+export default async function Page({ params, searchParams }: Props) {
+  const data = await getActivityDetails(params.id);
+
   const scheduleHash = createScheduleHashMap(mockData.schedules);
 
   const scheduledDates = mockData.schedules?.map((schedule) => parseISO(schedule.date));
+
+  const currentPage = Number(searchParams?.page) || 1;
 
   return (
     <main>
@@ -83,6 +169,14 @@ export default function Page({ params }: Props) {
         price={mockData.price}
         scheduleHash={scheduleHash}
         scheduledDates={scheduledDates}
+      />
+
+      <ReviewTemplate
+        ratings={4.5}
+        reviewCount={80}
+        reviews={mockRevs}
+        currentPage={currentPage}
+        activityId={params.id}
       />
     </main>
   );

--- a/src/components/molecules/review-card/ReviewCard.tsx
+++ b/src/components/molecules/review-card/ReviewCard.tsx
@@ -12,7 +12,7 @@ export default function ReviewCard({ review }: Props) {
     : format(review.createdAt, 'yy.MM.dd');
 
   return (
-    <div className="flex gap-[16px]">
+    <div className="flex gap-[16px] p-[24px]">
       <div className="relative h-45pxr w-45pxr shrink-0 overflow-hidden rounded-full">
         <Image src={review.user.profileImageUrl} fill alt="" objectFit="cover" />
       </div>

--- a/src/components/molecules/review-card/ReviewCard.tsx
+++ b/src/components/molecules/review-card/ReviewCard.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image';
+import { Review } from '@/types/review';
+import { format } from 'date-fns';
+
+interface Props {
+  review: Review;
+}
+
+export default function ReviewCard({ review }: Props) {
+  const formattedDate = review.updatedAt
+    ? format(review.updatedAt, 'yy.MM.dd')
+    : format(review.createdAt, 'yy.MM.dd');
+
+  return (
+    <div className="flex gap-[16px]">
+      <div className="relative h-45pxr w-45pxr shrink-0 overflow-hidden rounded-full">
+        <Image src={review.user.profileImageUrl} fill alt="" objectFit="cover" />
+      </div>
+
+      <div>
+        <div className="flex items-center gap-[4px]">
+          <span className="font-[700]">{review.user.nickname}</span>
+          <span className="text-14pxr"> |</span>
+          <span className="text-var-gray3">{formattedDate}</span>
+        </div>
+        <p>{review.content}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/review-overview/ReviewOverview.tsx
+++ b/src/components/molecules/review-overview/ReviewOverview.tsx
@@ -1,0 +1,27 @@
+import Image from 'next/image';
+import { getRatingDescription } from '@/models/activity-reservation/get-rating-description';
+
+interface Props {
+  ratings: number;
+  reviewCount: number;
+}
+
+export default function ReviewOverview({ ratings, reviewCount }: Props) {
+  const rateText = getRatingDescription(ratings);
+  const formattedReviewCount = reviewCount.toLocaleString('en-US');
+  return (
+    <div className="flex flex-col gap-[24px] px-[24px]">
+      <span className="text-20pxr font-[700]">후기</span>
+      <div className="flex items-center gap-[16px]">
+        <span className="text-50pxr font-[600]">{ratings}</span>
+        <div className="flex flex-col gap-[8px]">
+          <span>{rateText}</span>
+          <div className="flex gap-[6px]">
+            <Image src="/star-icon.svg" width={16} height={16} alt="" />
+            <span>{formattedReviewCount}개 후기</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
+++ b/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
@@ -25,7 +25,7 @@ export default function ActivityReservationBar({ price, scheduleHash, scheduledD
     : '날짜 선택하기';
 
   return (
-    <div className="fixed bottom-[0px] left-[0px] right-[0px] flex w-full justify-between border-t border-[#a1a1a1] bg-white p-[16px]">
+    <div className="fixed bottom-[0px] left-[0px] right-[0px] z-10 flex w-full justify-between border-t border-[#a1a1a1] bg-white p-[16px]">
       <div className="flex flex-col gap-8pxr">
         <div className="flex gap-6pxr text-20pxr font-[700] leading-[26px]">
           <span>₩{price * participants}</span>

--- a/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
+++ b/src/components/organisms/activity-reservation-bar/ActivityReservationBar.tsx
@@ -25,7 +25,7 @@ export default function ActivityReservationBar({ price, scheduleHash, scheduledD
     : '날짜 선택하기';
 
   return (
-    <div className="fixed bottom-[0px] left-[0px] right-[0px] flex w-full justify-between border-t border-[#a1a1a1] p-[16px]">
+    <div className="fixed bottom-[0px] left-[0px] right-[0px] flex w-full justify-between border-t border-[#a1a1a1] bg-white p-[16px]">
       <div className="flex flex-col gap-8pxr">
         <div className="flex gap-6pxr text-20pxr font-[700] leading-[26px]">
           <span>₩{price * participants}</span>

--- a/src/components/organisms/review-list/ReviewList.tsx
+++ b/src/components/organisms/review-list/ReviewList.tsx
@@ -1,0 +1,21 @@
+import ReviewCard from '@/components/molecules/review-card/ReviewCard';
+import { Review } from '@/types/review';
+
+interface Props {
+  reviews: Review[];
+}
+
+export default function ReviewList({ reviews }: Props) {
+  return (
+    <div>
+      {reviews.map((review, index) => (
+        <div
+          key={review.id}
+          className={`border-b ${index === reviews.length - 1 ? '' : 'border-var-gray4'}`}
+        >
+          <ReviewCard review={review} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/organisms/review-pagination/ReviewPagination.tsx
+++ b/src/components/organisms/review-pagination/ReviewPagination.tsx
@@ -1,0 +1,119 @@
+import Link from 'next/link';
+import Image from 'next/image';
+interface args {
+  currentPage: number;
+  totalPage: number;
+}
+
+const RentderPageNumbers = ({ currentPage, totalPage }: args) => {
+  let start: number;
+  let end: number;
+
+  // 전페 페이지가 5페이지 이하일 때
+  if (totalPage <= 5) {
+    start = 1;
+    end = totalPage;
+  } else {
+    //시작페이지 렌더링
+    if (currentPage <= 3) {
+      start = 1;
+      end = 5;
+    } //마지막페이지 렌더링
+    else if (currentPage >= totalPage - 2) {
+      start = totalPage - 4;
+      end = totalPage;
+    } //중간페이지 렌더링
+    else {
+      start = currentPage - 2;
+      end = currentPage + 2;
+    }
+  }
+
+  const numbers = Array.from({ length: end - start + 1 }, (_, i) => start + i);
+  return numbers;
+};
+
+interface Props {
+  totalPage: number;
+  currentPage: number;
+  activityId: number;
+}
+
+export default function ReviewPagination({ currentPage, activityId, totalPage }: Props) {
+  const numbers = RentderPageNumbers({ currentPage: currentPage, totalPage: totalPage });
+  return (
+    <div className="flex h-fit items-center gap-[10px]">
+      <PrevButton
+        currentPage={currentPage}
+        href={`/activity/${activityId}?page=${currentPage - 1}`}
+      />
+      <PageNumberButton currentPage={currentPage} numbers={numbers} activityId={activityId} />
+      <NextButton
+        currentPage={currentPage}
+        totalPage={totalPage}
+        href={`/activity/${activityId}?page=${currentPage + 1}`}
+      />
+    </div>
+  );
+}
+
+interface PrevButtonProp {
+  href: string;
+  currentPage: number;
+}
+
+function PrevButton({ href, currentPage }: PrevButtonProp) {
+  return (
+    <Link href={href} scroll={false} className="h-[55px]">
+      <button className="max-md:size-[40px] relative size-[55px]" disabled={currentPage === 1}>
+        <Image
+          fill
+          src={currentPage === 1 ? '/pagination-left-invalid.svg' : '/pagination-left.svg'}
+          alt="이전 페이지"
+        />
+      </button>
+    </Link>
+  );
+}
+
+interface NextButtonProp {
+  href: string;
+  currentPage: number;
+  totalPage: number;
+}
+
+function NextButton({ currentPage, href, totalPage }: NextButtonProp) {
+  return (
+    <Link href={href} scroll={false} className="h-[55px]">
+      <button
+        className="max-md:size-[40px] relative size-[55px]"
+        disabled={currentPage === totalPage}
+      >
+        <Image
+          fill
+          src={
+            currentPage === totalPage ? '/pagination-right-invalid.svg' : '/pagination-right.svg'
+          }
+          alt="이전 페이지"
+        />
+      </button>
+    </Link>
+  );
+}
+
+interface NumberProps {
+  currentPage: number;
+  activityId: number;
+  numbers: number[];
+}
+function PageNumberButton({ currentPage, activityId, numbers }: NumberProps) {
+  return numbers.map((number) => (
+    <Link href={`/activity/${activityId}?page=${number}`} key={number} scroll={false}>
+      <button
+        className={`py-17 text-base max-md:size-[40px] size-[55px] items-center justify-center rounded-2xl border-[1px] border-var-green-dark text-[18pxr] text-var-green-dark ${number === currentPage ? 'bg-var-green-dark text-white' : 'text-gray-600'}`}
+      >
+        {number}
+      </button>
+    </Link>
+  ));
+}

--- a/src/components/templates/review-template/ReviewTemplate.tsx
+++ b/src/components/templates/review-template/ReviewTemplate.tsx
@@ -1,0 +1,32 @@
+import ReviewOverview from '@/components/molecules/review-overview/ReviewOverview';
+import ReviewPagination from '@/components/organisms/review-pagination/ReviewPagination';
+import ReviewList from '@/components/organisms/review-list/ReviewList';
+import { Review } from '@/types/review';
+
+interface Props {
+  ratings: number;
+  reviewCount: number;
+  reviews: Review[];
+  currentPage: number;
+  activityId: number;
+}
+
+export default function ReviewTemplate({
+  ratings,
+  reviewCount,
+  reviews,
+  currentPage,
+  activityId,
+}: Props) {
+  const totalPage = Math.ceil(reviewCount / 3);
+
+  return (
+    <div className="flex flex-col py-[40px]">
+      <ReviewOverview ratings={ratings} reviewCount={reviewCount} />
+      <ReviewList reviews={reviews} />
+      <div className="py-[200px]">
+        <ReviewPagination totalPage={totalPage} currentPage={currentPage} activityId={activityId} />
+      </div>
+    </div>
+  );
+}

--- a/src/models/activity-reservation/get-rating-description.ts
+++ b/src/models/activity-reservation/get-rating-description.ts
@@ -1,0 +1,15 @@
+export const getRatingDescription = (rating: number): string => {
+  if (rating === 5) {
+    return '극락';
+  } else if (rating > 4) {
+    return '매우 만족';
+  } else if (rating > 3) {
+    return '만족';
+  } else if (rating > 2) {
+    return '불만족';
+  } else if (rating > 1) {
+    return '매우 불만족';
+  } else {
+    return '최악';
+  }
+};

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,0 +1,13 @@
+export interface Review {
+  id: number;
+  user: {
+    profileImageUrl: string;
+    nickname: string;
+    id: number;
+  };
+  activityId: number;
+  rating: number;
+  content: string;
+  createdAt: string;
+  updatedAt?: string;
+}


### PR DESCRIPTION
## 어떤 기능인가요?

리뷰를 페이지별로 보여주는 기능

## 작업 상세 내용

- [x] 리뷰 리스트 생성
- [x] searchParams를 이용한 페이지네이션 구현


## 테스트 방법 (선택)

/activity/1594 접속
없는 activity id에 접속시 에러 뜹니다

## 캡처 혹은 관련 자료 (피그마 링크 등) 
![image](https://github.com/user-attachments/assets/1f6c9a95-811e-45f8-94bc-a2f0ee4b27c5)

## 고민되거나 어려운 부분 (선택)
- 기존에 만들어진 공용 페이지네이션 기반으로 만들었는데 기존걸 수정하면 에러가 뜰것같아서 일단 ReviewPagination 컴포넌트에 모든 자식 컴포넌트들까지 모아두었습니다. 금일 회의에서 논의 후 다시 컴포넌트를 나눌 생각입니다.

- 아직 리뷰 데이터 페칭함수는 구현이 안되어있습니다. 현재는 임시데이터로 렌더링만 보여주고있습니다.
> 이거 중점으로 봐주세요 👀
리뷰의 계층적 구조는 
ReviewCard (몰큘)-> ReviewList (오거니즘)-> ReviewTemplate (템플릿)순입니다
ReviewTemplate의 자식으로 ReviewPagination도 포함돼있습니다