### PR TITLE
Feat: 메인페이지 인기체험 슬라이더 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-toastify": "^10.0.5",
         "redis": "^4.6.15",
         "tailwind-merge": "^2.3.0",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^4.5.4"
       },
@@ -16560,6 +16561,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.1.6",
         "ioredis": "^5.4.1",
+        "lodash": "^4.17.21",
         "lucide-react": "^0.400.0",
         "next": "14.2.4",
         "react": "^18",
@@ -12635,8 +12636,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-toastify": "^10.0.5",
     "redis": "^4.6.15",
     "tailwind-merge": "^2.3.0",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^4.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.1.6",
     "ioredis": "^5.4.1",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.400.0",
     "next": "14.2.4",
     "react": "^18",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,8 +18,8 @@ export default async function Home() {
       <Banner activity={bestActivitiesData.activities[0]} />
       <InnerLayout>
         <SearchActivity />
-        <BestActivities activitiesData={bestActivitiesData} />
       </InnerLayout>
+      <BestActivities activitiesData={bestActivitiesData} />
     </>
   );
 }

--- a/src/components/atoms/inner-layout/InnerLayout.tsx
+++ b/src/components/atoms/inner-layout/InnerLayout.tsx
@@ -7,6 +7,6 @@ interface Props {
 }
 
 export default function InnerLayout({ mobilePx, children, className = '' }: Props) {
-  const pxStyle = mobilePx === 'keep' ? 'px-24pxr' : 'px-16pxr md:px-24pxr';
+  const pxStyle = mobilePx === 'keep' ? 'px-[24px]' : 'px-[16px] md:[px-24px]';
   return <div className={`mx-auto w-full max-w-1248pxr ${pxStyle} ${className}`}>{children}</div>;
 }

--- a/src/components/atoms/review-rating/ReviewRating.tsx
+++ b/src/components/atoms/review-rating/ReviewRating.tsx
@@ -9,7 +9,7 @@ interface Props {
 export default function ReviewRating({ rating, reviewCount, color }: Props) {
   const imageSrc = !color ? '/star-icon.svg' : '/star-bold.svg';
   return (
-    <div className="flex items-center gap-5pxr">
+    <div className="flex items-center gap-[5px]">
       <Image src={imageSrc} width={18} height={18} alt="별" />
       <span
         className={`text-14pxr md:text-16pxr ${color === 'white' ? 'text-14pxr font-[600] text-white' : color === 'gray' ? 'font-[500]' : 'font-[400]'}`}

--- a/src/components/molecules/card/ActivityCard.tsx
+++ b/src/components/molecules/card/ActivityCard.tsx
@@ -17,7 +17,7 @@ export default function ActivityCard({ activity, isBest }: Props) {
   return (
     <Link
       href=""
-      className={`scroll-snap-align-start flex flex-none ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:h-384pxr md:w-[calc((100%-48px)/3)]' : 'w-168pxr flex-col gap-16pxr md:w-221pxr lg:w-283pxr'} `}
+      className={`flex flex-none snap-start ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:h-384pxr md:w-[calc((100%-48px)/3)]' : 'w-168pxr flex-col gap-16pxr md:w-221pxr lg:w-283pxr'} `}
     >
       <Image
         src={isImageError ? defaultImage : activity.bannerImageUrl}

--- a/src/components/molecules/card/ActivityCard.tsx
+++ b/src/components/molecules/card/ActivityCard.tsx
@@ -17,7 +17,7 @@ export default function ActivityCard({ activity, isBest }: Props) {
   return (
     <Link
       href=""
-      className={`flex flex-none snap-start ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:h-384pxr md:w-384pxr lg:w-[calc((100%-48px)/3)]' : 'w-168pxr flex-col gap-[16px] md:w-221pxr lg:w-283pxr'} `}
+      className={`flex flex-none snap-start ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:size-384pxr' : 'w-168pxr flex-col gap-[16px] md:w-221pxr lg:w-283pxr'} `}
     >
       <Image
         src={isImageError ? defaultImage : activity.bannerImageUrl}

--- a/src/components/molecules/card/ActivityCard.tsx
+++ b/src/components/molecules/card/ActivityCard.tsx
@@ -17,7 +17,7 @@ export default function ActivityCard({ activity, isBest }: Props) {
   return (
     <Link
       href=""
-      className={`flex flex-none snap-start ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:h-384pxr md:w-[calc((100%-48px)/3)]' : 'w-168pxr flex-col gap-16pxr md:w-221pxr lg:w-283pxr'} `}
+      className={`flex flex-none snap-start ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:h-384pxr md:w-384pxr lg:w-[calc((100%-48px)/3)]' : 'w-168pxr flex-col gap-[16px] md:w-221pxr lg:w-283pxr'} `}
     >
       <Image
         src={isImageError ? defaultImage : activity.bannerImageUrl}
@@ -28,7 +28,7 @@ export default function ActivityCard({ activity, isBest }: Props) {
         onError={() => setIsImageError(true)}
       />
       <div
-        className={`w-full ${isBest ? 'relative flex flex-col justify-end gap-6pxr px-20pxr py-24pxr md:gap-20pxr md:py-30pxr' : 'file:'}`}
+        className={`w-full ${isBest ? 'relative flex flex-col justify-end gap-[6px] px-[20px] py-[24px] md:gap-[20px] md:py-[30px]' : ''}`}
         style={
           isBest
             ? {
@@ -44,11 +44,11 @@ export default function ActivityCard({ activity, isBest }: Props) {
           color={isBest ? 'white' : 'gray'}
         />
         <h3
-          className={`break-keep text-18pxr leading-[120%] ${isBest ? 'w-full text-18pxr font-[700] text-white md:w-[80%] md:text-30pxr' : 'mt-10pxr font-[600] md:text-24pxr'} `}
+          className={`break-keep text-18pxr leading-[120%] ${isBest ? 'w-full text-18pxr font-[700] text-white md:w-[80%] md:text-30pxr' : 'mt-[10px] font-[600] md:text-24pxr'} `}
         >
           {activity.title}
         </h3>
-        <div className={`flex items-center gap-5pxr ${isBest ? '' : 'mt-8pxr'}`}>
+        <div className={`flex items-center gap-[5px] ${isBest ? '' : 'mt-[8px]'}`}>
           <b
             className={`font-[700] ${isBest ? 'text-16pxr text-white md:text-20pxr' : 'text-20pxr md:text-28pxr'}`}
           >

--- a/src/components/molecules/card/ActivityCard.tsx
+++ b/src/components/molecules/card/ActivityCard.tsx
@@ -17,7 +17,7 @@ export default function ActivityCard({ activity, isBest }: Props) {
   return (
     <Link
       href=""
-      className={`flex ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:size-384pxr' : 'w-168pxr flex-col gap-16pxr md:w-221pxr lg:w-283pxr'} `}
+      className={`scroll-snap-align-start flex flex-none ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:h-384pxr md:w-[calc((100%-48px)/3)]' : 'w-168pxr flex-col gap-16pxr md:w-221pxr lg:w-283pxr'} `}
     >
       <Image
         src={isImageError ? defaultImage : activity.bannerImageUrl}

--- a/src/components/molecules/search/SearchActivity.tsx
+++ b/src/components/molecules/search/SearchActivity.tsx
@@ -8,15 +8,15 @@ export default function SearchActivity() {
   const handleChange = () => {};
 
   return (
-    <div className="relative -top-60pxr flex flex-col gap-15pxr rounded-[16px] bg-white px-24pxr py-16pxr shadow-[0_4px_16px_0_rgba(17,34,17,0.05)] md:gap-30pxr md:py-32pxr">
+    <div className="relative -mt-[60px] flex flex-col gap-[15px] rounded-[16px] bg-white px-[24px] py-[16px] shadow-[0_4px_16px_0_rgba(17,34,17,0.05)] md:gap-[30px] md:py-[32px]">
       <h3 className="text-16pxr font-[700] md:text-20pxr">무엇을 체험하고 싶으신가요?</h3>
-      <form onSubmit={handleSubmit} className="flex w-full gap-12pxr">
+      <form onSubmit={handleSubmit} className="flex w-full gap-[12px]">
         <SearchInput onChange={handleChange} />
         <Button
           text="검색하기"
           color="black"
           type="submit"
-          className="h-56pxr shrink-0 !rounded-[4px] px-20pxr md:px-40pxr"
+          className="h-56pxr shrink-0 !rounded-[4px] px-[20pxr] md:px-[40px]"
         />
       </form>
     </div>

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -11,7 +11,7 @@ export default function BestActivityCardList({ activitiesData, carouselRef }: Pr
   return (
     <ul
       ref={carouselRef}
-      className="scroll-snap-x-mandatory scroll-snap-both scrollbar-hide flex w-full gap-[24px] overflow-x-auto"
+      className="scrollbar-hide flex w-full snap-x snap-proximity gap-[24px] overflow-x-auto"
     >
       {activitiesData.activities.map((activity) => (
         <ActivityCard key={activity.id} activity={activity} isBest />

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -1,18 +1,20 @@
 import ActivityCard from '@/components/molecules/card/ActivityCard';
 import { ActivityResponse } from '@/types/activity';
-import React from 'react';
+import React, { LegacyRef } from 'react';
 
 interface Props {
   activitiesData: ActivityResponse;
+  carouselRef: LegacyRef<HTMLUListElement> | undefined;
 }
 
-export default function BestActivityCardList({ activitiesData }: Props) {
+export default function BestActivityCardList({ activitiesData, carouselRef }: Props) {
   return (
-    <ul className="flex w-full gap-[24px] overflow-hidden">
+    <ul
+      ref={carouselRef}
+      className="scroll-snap-x-mandatory scroll-snap-both scrollbar-hide flex w-full gap-[24px] overflow-x-auto"
+    >
       {activitiesData.activities.map((activity) => (
-        <li key={activity.id}>
-          <ActivityCard activity={activity} isBest />
-        </li>
+        <ActivityCard key={activity.id} activity={activity} isBest />
       ))}
     </ul>
   );

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -4,18 +4,18 @@ import React, { LegacyRef } from 'react';
 
 interface Props {
   activitiesData: ActivityResponse;
-  carouselRef: LegacyRef<HTMLUListElement> | undefined;
+  carouselRef: LegacyRef<HTMLDivElement> | undefined;
 }
 
 export default function BestActivityCardList({ activitiesData, carouselRef }: Props) {
   return (
-    <ul
+    <div
       ref={carouselRef}
-      className="scrollbar-hide flex w-full snap-x snap-proximity gap-[16px] overflow-x-auto md:gap-[24px]"
+      className="scrollbar-hide flex w-full snap-x snap-mandatory gap-[16px] overflow-x-auto md:gap-[24px]"
     >
       {activitiesData.activities.map((activity) => (
         <ActivityCard key={activity.id} activity={activity} isBest />
       ))}
-    </ul>
+    </div>
   );
 }

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -11,7 +11,7 @@ export default function BestActivityCardList({ activitiesData, carouselRef }: Pr
   return (
     <div
       ref={carouselRef}
-      className="scrollbar-hide flex w-full snap-x snap-mandatory gap-[16px] overflow-x-auto md:gap-[24px]"
+      className="flex w-full snap-x snap-mandatory gap-[16px] overflow-x-auto scrollbar-hide md:gap-[24px] md:px-[24px]"
     >
       {activitiesData.activities.map((activity) => (
         <ActivityCard key={activity.id} activity={activity} isBest />

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -11,7 +11,7 @@ export default function BestActivityCardList({ activitiesData, carouselRef }: Pr
   return (
     <ul
       ref={carouselRef}
-      className="scrollbar-hide flex w-full snap-x snap-proximity gap-[24px] overflow-x-auto"
+      className="scrollbar-hide flex w-full snap-x snap-proximity gap-[16px] overflow-x-auto md:gap-[24px]"
     >
       {activitiesData.activities.map((activity) => (
         <ActivityCard key={activity.id} activity={activity} isBest />

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -43,10 +43,10 @@ export default function BestActivities({ activitiesData }: Props) {
   }, []);
 
   return (
-    <div className="mt-40pxr flex flex-col gap-33pxr">
+    <div className="mt-[24px] flex flex-col gap-[16px] md:gap-[33px] lg:mt-[40px]">
       <div className="flex items-center justify-between">
-        <h3 className="text-36pxr font-[700]">🔥 인기 체험</h3>
-        <div className="hidden gap-12pxr lg:flex">
+        <h3 className="text-18pxr font-[700] md:text-36pxr">🔥 인기 체험</h3>
+        <div className="hidden gap-[12px] lg:flex">
           {arrowList.map((arrow) => (
             <button key={arrow.name} onClick={arrow.onClick}>
               <Image

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -11,7 +11,9 @@ interface Props {
 
 export default function BestActivities({ activitiesData }: Props) {
   const [scrollAmount, setScrollAmount] = useState(0);
-  const carouselRef = useRef<HTMLUListElement>(null);
+  const [isPrevDisabled, setIsPrevDisabled] = useState(true);
+  const [isNextDisabled, setIsNextDisabled] = useState(false);
+  const carouselRef = useRef<HTMLDivElement>(null);
   const arrowList = [
     {
       name: 'prev',
@@ -21,6 +23,7 @@ export default function BestActivities({ activitiesData }: Props) {
           carouselRef.current.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
         }
       },
+      disabled: isPrevDisabled,
     },
     {
       name: 'next',
@@ -30,8 +33,19 @@ export default function BestActivities({ activitiesData }: Props) {
           carouselRef.current.scrollBy({ left: scrollAmount, behavior: 'smooth' });
         }
       },
+      disabled: isNextDisabled,
     },
   ];
+  console.log(isNextDisabled);
+
+  const handleScroll = () => {
+    if (carouselRef.current) {
+      const { scrollLeft, scrollWidth, clientWidth } = carouselRef.current;
+      setIsPrevDisabled(scrollLeft === 0);
+      setIsNextDisabled(scrollLeft + clientWidth >= scrollWidth);
+      console.log(scrollLeft, clientWidth, scrollWidth);
+    }
+  };
 
   useEffect(() => {
     if (carouselRef.current) {
@@ -39,6 +53,17 @@ export default function BestActivities({ activitiesData }: Props) {
       const maxScroll = 1224;
       const calculatedScroll = Math.min(containerWidth, maxScroll) / 3;
       setScrollAmount(calculatedScroll);
+      handleScroll();
+    }
+  }, []);
+
+  useEffect(() => {
+    const carousel = carouselRef.current;
+    if (carousel) {
+      carousel.addEventListener('scroll', handleScroll);
+      return () => {
+        carousel.removeEventListener('scroll', handleScroll);
+      };
     }
   }, []);
 
@@ -48,7 +73,7 @@ export default function BestActivities({ activitiesData }: Props) {
         <h3 className="text-18pxr font-[700] md:text-36pxr">🔥 인기 체험</h3>
         <div className="hidden gap-[12px] lg:flex">
           {arrowList.map((arrow) => (
-            <button key={arrow.name} onClick={arrow.onClick}>
+            <button key={arrow.name} onClick={arrow.onClick} disabled={arrow.disabled}>
               <Image
                 src="/arrow-right.svg"
                 width={44}

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -43,7 +43,6 @@ export default function BestActivities({ activitiesData }: Props) {
       const { scrollLeft, scrollWidth, clientWidth } = carouselRef.current;
       setIsPrevDisabled(scrollLeft === 0);
       setIsNextDisabled(scrollLeft + clientWidth >= scrollWidth);
-      console.log(scrollLeft, clientWidth, scrollWidth);
     }
   };
 
@@ -73,7 +72,12 @@ export default function BestActivities({ activitiesData }: Props) {
         <h3 className="text-18pxr font-[700] md:text-36pxr">🔥 인기 체험</h3>
         <div className="hidden gap-[12px] lg:flex">
           {arrowList.map((arrow) => (
-            <button key={arrow.name} onClick={arrow.onClick} disabled={arrow.disabled}>
+            <button
+              key={arrow.name}
+              onClick={arrow.onClick}
+              disabled={arrow.disabled}
+              className="disabled:opacity-[50%]"
+            >
               <Image
                 src="/arrow-right.svg"
                 width={44}

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import InnerLayout from '@/components/atoms/inner-layout/InnerLayout';
 import BestActivityCardList from '@/components/organisms/card-list/BestActivityCardList';
 import { ActivityResponse } from '@/types/activity';
 import { throttle } from 'lodash';
 import Image from 'next/image';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface Props {
   activitiesData: ActivityResponse;
@@ -50,7 +51,7 @@ export default function BestActivities({ activitiesData }: Props) {
     if (carouselRef.current) {
       const containerWidth = carouselRef.current.offsetWidth + 24;
       const maxScroll = 1224;
-      const calculatedScroll = Math.min(containerWidth, maxScroll) / 3;
+      const calculatedScroll = Math.min(containerWidth, maxScroll) / 3 - 24;
       setScrollAmount(calculatedScroll);
       updateScrollState();
     }
@@ -68,7 +69,7 @@ export default function BestActivities({ activitiesData }: Props) {
 
   return (
     <div className="mt-[24px] flex flex-col gap-[16px] md:gap-[33px] lg:mt-[40px]">
-      <div className="flex items-center justify-between">
+      <InnerLayout className="flex items-center justify-between">
         <h3 className="text-18pxr font-[700] md:text-36pxr">🔥 인기 체험</h3>
         <div className="hidden gap-[12px] lg:flex">
           {arrowList.map((arrow) => (
@@ -88,8 +89,10 @@ export default function BestActivities({ activitiesData }: Props) {
             </button>
           ))}
         </div>
+      </InnerLayout>
+      <div className="mx-auto w-full max-w-1200pxr">
+        <BestActivityCardList activitiesData={activitiesData} carouselRef={carouselRef} />
       </div>
-      <BestActivityCardList activitiesData={activitiesData} carouselRef={carouselRef} />
     </div>
   );
 }

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -37,7 +37,7 @@ export default function BestActivities({ activitiesData }: Props) {
     if (carouselRef.current) {
       const containerWidth = carouselRef.current.offsetWidth + 24;
       const maxScroll = 1224;
-      const calculatedScroll = Math.min(containerWidth, maxScroll);
+      const calculatedScroll = Math.min(containerWidth, maxScroll) / 3;
       setScrollAmount(calculatedScroll);
     }
   }, []);

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -1,32 +1,54 @@
+'use client';
+
 import BestActivityCardList from '@/components/organisms/card-list/BestActivityCardList';
 import { ActivityResponse } from '@/types/activity';
 import Image from 'next/image';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface Props {
   activitiesData: ActivityResponse;
 }
 
 export default function BestActivities({ activitiesData }: Props) {
+  const [scrollAmount, setScrollAmount] = useState(0);
+  const carouselRef = useRef<HTMLUListElement>(null);
   const arrowList = [
     {
       name: 'prev',
       style: 'scale-x-[-1]',
-      onClick: () => {},
+      onClick: () => {
+        if (carouselRef.current) {
+          carouselRef.current.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
+        }
+      },
     },
     {
       name: 'next',
       style: '',
-      onClick: () => {},
+      onClick: () => {
+        if (carouselRef.current) {
+          carouselRef.current.scrollBy({ left: scrollAmount, behavior: 'smooth' });
+        }
+      },
     },
   ];
+
+  useEffect(() => {
+    if (carouselRef.current) {
+      const containerWidth = carouselRef.current.offsetWidth + 24;
+      const maxScroll = 1224;
+      const calculatedScroll = Math.min(containerWidth, maxScroll);
+      setScrollAmount(calculatedScroll);
+    }
+  }, []);
+
   return (
     <div className="mt-40pxr flex flex-col gap-33pxr">
       <div className="flex items-center justify-between">
         <h3 className="text-36pxr font-[700]">🔥 인기 체험</h3>
         <div className="hidden gap-12pxr lg:flex">
           {arrowList.map((arrow) => (
-            <button key={arrow.name}>
+            <button key={arrow.name} onClick={arrow.onClick}>
               <Image
                 src="/arrow-right.svg"
                 width={44}
@@ -38,7 +60,7 @@ export default function BestActivities({ activitiesData }: Props) {
           ))}
         </div>
       </div>
-      <BestActivityCardList activitiesData={activitiesData} />
+      <BestActivityCardList activitiesData={activitiesData} carouselRef={carouselRef} />
     </div>
   );
 }

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -2,8 +2,9 @@
 
 import BestActivityCardList from '@/components/organisms/card-list/BestActivityCardList';
 import { ActivityResponse } from '@/types/activity';
+import { throttle } from 'lodash';
 import Image from 'next/image';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 interface Props {
   activitiesData: ActivityResponse;
@@ -36,15 +37,14 @@ export default function BestActivities({ activitiesData }: Props) {
       disabled: isNextDisabled,
     },
   ];
-  console.log(isNextDisabled);
 
-  const handleScroll = () => {
+  const updateScrollState = throttle(() => {
     if (carouselRef.current) {
       const { scrollLeft, scrollWidth, clientWidth } = carouselRef.current;
       setIsPrevDisabled(scrollLeft === 0);
       setIsNextDisabled(scrollLeft + clientWidth >= scrollWidth);
     }
-  };
+  }, 200);
 
   useEffect(() => {
     if (carouselRef.current) {
@@ -52,19 +52,19 @@ export default function BestActivities({ activitiesData }: Props) {
       const maxScroll = 1224;
       const calculatedScroll = Math.min(containerWidth, maxScroll) / 3;
       setScrollAmount(calculatedScroll);
-      handleScroll();
+      updateScrollState();
     }
-  }, []);
+  }, [updateScrollState]);
 
   useEffect(() => {
     const carousel = carouselRef.current;
     if (carousel) {
-      carousel.addEventListener('scroll', handleScroll);
+      carousel.addEventListener('scroll', updateScrollState);
       return () => {
-        carousel.removeEventListener('scroll', handleScroll);
+        carousel.removeEventListener('scroll', updateScrollState);
       };
     }
-  }, []);
+  }, [updateScrollState]);
 
   return (
     <div className="mt-[24px] flex flex-col gap-[16px] md:gap-[33px] lg:mt-[40px]">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -105,7 +105,7 @@ const config = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [require('tailwindcss-animate'), require('tailwind-scrollbar-hide')],
 } satisfies Config;
 
 export default config;


### PR DESCRIPTION
## 어떤 기능인가요?

인기 체험 슬라이더 구현, 반응형 UI는 아직 미완성입니다.

## 작업 상세 내용

- [x] most_reviewed 순으로 9개만 받아와서 슬라이더로 넘기면서 보여주도록 구현
- [ ] 모바일, 테블릿에서는 양 옆이 패딩 값 없이 슬라이드되어야 해서 UI 수정 중

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

https://github.com/user-attachments/assets/89729b49-6ccc-4f1a-9f78-8148449e7f86


https://github.com/user-attachments/assets/1e403300-ae6c-4a97-8c8a-402e2e749099

