### PR TITLE
Feat: 메인페이지 인기 체험 구현 완료, 필터링 체험 작업 중

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import SearchActivity from '@/components/molecules/search/SearchActivity';
 import Header from '@/components/templates/header/Header';
 import Banner from '@/components/templates/main/Banner';
 import BestActivities from '@/components/templates/main/BestActivities';
+import FilteredActivities from '@/components/templates/main/FilteredActivities';
 import { getActivities } from '@/queries/activities/get-activities';
 
 export default async function Home() {
@@ -20,6 +21,7 @@ export default async function Home() {
         <SearchActivity />
       </InnerLayout>
       <BestActivities activitiesData={bestActivitiesData} />
+      <FilteredActivities />
     </>
   );
 }

--- a/src/components/molecules/search/SearchActivity.tsx
+++ b/src/components/molecules/search/SearchActivity.tsx
@@ -16,7 +16,7 @@ export default function SearchActivity() {
           text="검색하기"
           color="black"
           type="submit"
-          className="h-56pxr shrink-0 !rounded-[4px] px-[20pxr] md:px-[40px]"
+          className="h-56pxr shrink-0 !rounded-[4px] px-[20px] md:px-[40px]"
         />
       </form>
     </div>

--- a/src/components/organisms/card-list/ActivityCardList.tsx
+++ b/src/components/organisms/card-list/ActivityCardList.tsx
@@ -1,0 +1,26 @@
+import ActivityCard from '@/components/molecules/card/ActivityCard';
+
+// 테스트용 mock 데이터 넣어둠
+export default function ActivityCardList() {
+  return (
+    <div>
+      <ActivityCard
+        activity={{
+          id: 0,
+          userId: 0,
+          title: 'string',
+          description: 'string',
+          category: 'string',
+          price: 0,
+          address: 'string',
+          bannerImageUrl:
+            'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/5-3_547_1720439740814.png',
+          rating: 0,
+          reviewCount: 0,
+          createdAt: '2024-07-15T22:24:48.809Z',
+          updatedAt: '2024-07-15T22:24:48.809Z',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -12,7 +12,7 @@ export default function BestActivityCardList({ activitiesData, carouselRef }: Pr
     <div className="w-full">
       <div
         ref={carouselRef}
-        className="flex snap-x snap-mandatory scroll-px-[16px] gap-[16px] overflow-x-auto px-[16px] scrollbar-hide md:scroll-px-[24px] md:gap-[24px] md:px-[24px]"
+        className="flex snap-x snap-mandatory scroll-px-[16px] gap-[16px] overflow-x-auto px-[16px] scrollbar-hide md:scroll-px-[24px] md:gap-[24px] md:px-[24px] xl:scroll-px-[0px]"
       >
         {activitiesData.activities.map((activity) => (
           <ActivityCard key={activity.id} activity={activity} isBest />

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -9,13 +9,15 @@ interface Props {
 
 export default function BestActivityCardList({ activitiesData, carouselRef }: Props) {
   return (
-    <div
-      ref={carouselRef}
-      className="flex w-full snap-x snap-mandatory gap-[16px] overflow-x-auto scrollbar-hide md:gap-[24px] md:px-[24px]"
-    >
-      {activitiesData.activities.map((activity) => (
-        <ActivityCard key={activity.id} activity={activity} isBest />
-      ))}
+    <div className="w-full">
+      <div
+        ref={carouselRef}
+        className="flex snap-x snap-mandatory scroll-px-[16px] gap-[16px] overflow-x-auto px-[16px] scrollbar-hide md:scroll-px-[24px] md:gap-[24px] md:px-[24px]"
+      >
+        {activitiesData.activities.map((activity) => (
+          <ActivityCard key={activity.id} activity={activity} isBest />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/organisms/nav-list/FilteredNavList.tsx
+++ b/src/components/organisms/nav-list/FilteredNavList.tsx
@@ -1,0 +1,11 @@
+import Button from '@/components/atoms/button/Button';
+
+export default function FilteredNavList() {
+  return (
+    <ul>
+      <li>
+        <Button text="문화예술" color="white" />
+      </li>
+    </ul>
+  );
+}

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -49,9 +49,9 @@ export default function BestActivities({ activitiesData }: Props) {
 
   useEffect(() => {
     if (carouselRef.current) {
-      const containerWidth = carouselRef.current.offsetWidth + 24;
+      const containerWidth = carouselRef.current.offsetWidth;
       const maxScroll = 1224;
-      const calculatedScroll = Math.min(containerWidth, maxScroll) / 3 - 24;
+      const calculatedScroll = Math.min(containerWidth, maxScroll) / 3;
       setScrollAmount(calculatedScroll);
       updateScrollState();
     }

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -1,0 +1,22 @@
+import DropdownMenu from '@/components/molecules/dropdown-menu/DropdownMenu';
+import ActivityCardList from '@/components/organisms/card-list/ActivityCardList';
+import FilteredNavList from '@/components/organisms/nav-list/FilteredNavList';
+import ReviewPagination from '@/components/organisms/review-pagination/ReviewPagination';
+import React from 'react';
+
+export default function FilteredActivities() {
+  return (
+    <>
+      <div>
+        <FilteredNavList />
+        <DropdownMenu text="테스트">
+          <p>테스트1</p>
+          <p>테스트2</p>
+        </DropdownMenu>
+      </div>
+      <h2>🛼 모든 체험</h2>
+      <ActivityCardList />
+      <ReviewPagination totalPage={1} currentPage={1} activityId={1} />
+    </>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -99,6 +99,7 @@ const config = {
       screens: {
         md: { min: '450px' },
         lg: { min: '1024px' },
+        xl: { min: '1245px' },
       },
       inset: {
         unset: 'unset',


### PR DESCRIPTION
## 어떤 기능인가요?

메인페이지 인기 체험 리스트 슬라이드 구현, 하단 필터링 체험 작업 중

## 작업 상세 내용

- [x] 라이브러리 없이 슬라이드 구현 
- [ ] 필터링 체험 리스트 구현 중

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

### [Mobile]
<img width="200" alt="스크린샷 2024-07-16 오전 11 53 53" src="https://github.com/user-attachments/assets/85fa8516-ead4-4250-98cb-2e78241882c2">

### [Tablet]
<img width="500" alt="스크린샷 2024-07-16 오전 11 54 40" src="https://github.com/user-attachments/assets/4cf245da-a797-408e-8480-0cfb31a1a297">

### [PC]
<img width="1550" alt="스크린샷 2024-07-16 오후 12 03 50" src="https://github.com/user-attachments/assets/003ebafb-a267-49a8-9a31-1506bc0b1a22">

## 고민되거나 어려운 부분 (선택)

동혁님이 저번에 소개해주신 CSS의 snap 기능을 활용해서 슬라이드 구현 완료했습니다! 👍👍


<br />