### PR TITLE
Feat: 메인페이지 필터링 api 구현, 반응형 UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { getActivities } from '@/queries/activities/get-activities';
 import { ActivityCategory, ActivitySort } from '@/types/activity';
 
 interface Props {
-  searchParams: { category: ActivityCategory; sort: ActivitySort };
+  searchParams: { category: ActivityCategory; sort: ActivitySort; page: number };
 }
 
 export default async function Home({ searchParams }: Props) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,9 +23,7 @@ export default async function Home({ searchParams }: Props) {
     <>
       <Header />
       <Banner activity={bestActivitiesData.activities[0]} />
-      <InnerLayout>
-        <SearchActivity />
-      </InnerLayout>
+      <SearchActivity />
       <BestActivities activitiesData={bestActivitiesData} />
       <FilteredActivities searchParams={searchParams} />
       <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,10 @@ import Banner from '@/components/templates/main/Banner';
 import BestActivities from '@/components/templates/main/BestActivities';
 import FilteredActivities from '@/components/templates/main/FilteredActivities';
 import { getActivities } from '@/queries/activities/get-activities';
-import { ActivityCategory } from '@/types/activity';
+import { ActivityCategory, ActivitySort } from '@/types/activity';
 
 interface Props {
-  searchParams: { category: ActivityCategory };
+  searchParams: { category: ActivityCategory; sort: ActivitySort };
 }
 
 export default async function Home({ searchParams }: Props) {

--- a/src/components/molecules/card/ActivityCard.tsx
+++ b/src/components/molecules/card/ActivityCard.tsx
@@ -17,7 +17,7 @@ export default function ActivityCard({ activity, isBest }: Props) {
   return (
     <Link
       href={`/activity/${activity.id}`}
-      className={`flex flex-none snap-start ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:size-384pxr' : 'w-168pxr flex-col gap-[16px] md:w-221pxr lg:w-283pxr'} `}
+      className={`flex flex-none snap-start ${isBest ? 'relative size-186pxr overflow-hidden rounded-[20px] md:size-384pxr' : 'flex-col gap-[16px]'} `}
     >
       <Image
         src={isImageError ? defaultImage : activity.bannerImageUrl}

--- a/src/components/molecules/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/molecules/dropdown-menu/DropdownMenu.tsx
@@ -35,7 +35,7 @@ export default function DropdownMenu({ text, children, className }: Props) {
     <div ref={dropdownRef} className={cn('relative flex w-full flex-col', className)}>
       <button
         onClick={handleToggle}
-        className="flex w-full justify-between rounded-[15px] border border-var-green-dark px-20pxr py-15pxr text-18pxr leading-[22px] text-var-green-dark"
+        className="flex w-full justify-between rounded-[15px] border border-var-green-dark px-[20px] py-[10px] text-14pxr leading-[22px] text-var-green-dark md:py-[15px] md:text-18pxr"
       >
         {text}
         <Image src="/arrow-down.svg" width={22} height={22} alt="dropdown" />
@@ -46,7 +46,7 @@ export default function DropdownMenu({ text, children, className }: Props) {
             {Children.map(children, (child, index) => (
               <li
                 className={cn(
-                  'w-full py-18pxr text-center',
+                  'w-full py-[9px] text-center text-14pxr md:py-[18px] md:text-18pxr',
                   index < Children.count(children) - 1 && 'border-var-gray-6 border-b',
                 )}
                 key={index}

--- a/src/components/molecules/pagination/Pagination.tsx
+++ b/src/components/molecules/pagination/Pagination.tsx
@@ -8,20 +8,20 @@ import { usePageControls } from '@/models/pagination/use-page-controls';
 
 interface Props {
   totalCount: number;
-  size: number;
+  size?: number;
   currentPage: number;
-  onPrev: () => void;
-  onNext: () => void;
-  onClick: (index: number) => void;
+  // onPrev: () => void;
+  // onNext: () => void;
+  // onClick: (index: number) => void;
 }
 
 export default function Pagination({
   totalCount = 50,
   size = 5,
   currentPage = 1,
-  onPrev,
-  onNext,
-  onClick,
+  // onPrev,
+  // onNext,
+  // onClick,
 }: Props) {
   /* 추후 상위 컴포넌트에서 사용될 커스텀훅입니다. */
   const { currentPageNumber, handlePageClick, handleNextButton, handlePrevButton } =

--- a/src/components/molecules/search/SearchActivity.tsx
+++ b/src/components/molecules/search/SearchActivity.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Button from '@/components/atoms/button/Button';
+import InnerLayout from '@/components/atoms/inner-layout/InnerLayout';
 import SearchInput from '@/components/atoms/input/SearchInput';
 
 export default function SearchActivity() {
@@ -8,17 +9,19 @@ export default function SearchActivity() {
   const handleChange = () => {};
 
   return (
-    <div className="relative -mt-[60px] flex flex-col gap-[15px] rounded-[16px] bg-white px-[24px] py-[16px] shadow-[0_4px_16px_0_rgba(17,34,17,0.05)] md:gap-[30px] md:py-[32px]">
-      <h3 className="text-16pxr font-[700] md:text-20pxr">무엇을 체험하고 싶으신가요?</h3>
-      <form onSubmit={handleSubmit} className="flex w-full gap-[12px]">
-        <SearchInput onChange={handleChange} />
-        <Button
-          text="검색하기"
-          color="black"
-          type="submit"
-          className="h-56pxr shrink-0 !rounded-[4px] px-[20px] md:px-[40px]"
-        />
-      </form>
-    </div>
+    <InnerLayout>
+      <div className="relative -mt-[60px] flex flex-col gap-[15px] rounded-[16px] bg-white px-[24px] py-[16px] shadow-[0_4px_16px_0_rgba(17,34,17,0.05)] md:gap-[30px] md:py-[32px]">
+        <h3 className="text-16pxr font-[700] md:text-20pxr">무엇을 체험하고 싶으신가요?</h3>
+        <form onSubmit={handleSubmit} className="flex w-full gap-[12px]">
+          <SearchInput onChange={handleChange} />
+          <Button
+            text="검색하기"
+            color="black"
+            type="submit"
+            className="h-56pxr shrink-0 !rounded-[4px] px-[20px] md:px-[40px]"
+          />
+        </form>
+      </div>
+    </InnerLayout>
   );
 }

--- a/src/components/organisms/card-list/ActivityCardList.tsx
+++ b/src/components/organisms/card-list/ActivityCardList.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function ActivityCardList({ activityList }: Props) {
   return (
-    <ul className="mt-[32px]">
+    <ul className="md2:grid-cols-3 mt-[32px] grid grid-cols-2 gap-x-[8px] gap-y-[24px] md:gap-x-[16px] md:gap-y-[32px] lg:grid-cols-4 lg:gap-x-[24px] lg:gap-y-[48px]">
       {activityList.map((activity) => (
         <li key={activity.id}>
           <ActivityCard activity={activity} />

--- a/src/components/organisms/card-list/ActivityCardList.tsx
+++ b/src/components/organisms/card-list/ActivityCardList.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function ActivityCardList({ activityList }: Props) {
   return (
-    <ul className="mt-[24px] grid grid-cols-2 gap-x-[8px] gap-y-[24px] md:mt-[32px] md:gap-x-[16px] md:gap-y-[32px] lg:grid-cols-4 lg:gap-x-[24px] lg:gap-y-[48px] md2:grid-cols-3">
+    <ul className="mt-[24px] grid grid-cols-2 gap-x-[8px] gap-y-[24px] md:mt-[32px] md:gap-x-[16px] md:gap-y-[32px] lg:grid-cols-4 lg:gap-x-[24px] lg:gap-y-[48px]">
       {activityList.map((activity) => (
         <li key={activity.id}>
           <ActivityCard activity={activity} />

--- a/src/components/organisms/card-list/ActivityCardList.tsx
+++ b/src/components/organisms/card-list/ActivityCardList.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function ActivityCardList({ activityList }: Props) {
   return (
-    <ul className="md2:grid-cols-3 mt-[32px] grid grid-cols-2 gap-x-[8px] gap-y-[24px] md:gap-x-[16px] md:gap-y-[32px] lg:grid-cols-4 lg:gap-x-[24px] lg:gap-y-[48px]">
+    <ul className="mt-[24px] grid grid-cols-2 gap-x-[8px] gap-y-[24px] md:mt-[32px] md:gap-x-[16px] md:gap-y-[32px] lg:grid-cols-4 lg:gap-x-[24px] lg:gap-y-[48px] md2:grid-cols-3">
       {activityList.map((activity) => (
         <li key={activity.id}>
           <ActivityCard activity={activity} />

--- a/src/components/organisms/card-list/BestActivityCardList.tsx
+++ b/src/components/organisms/card-list/BestActivityCardList.tsx
@@ -12,7 +12,7 @@ export default function BestActivityCardList({ activitiesData, carouselRef }: Pr
     <div className="w-full">
       <div
         ref={carouselRef}
-        className="flex snap-x snap-mandatory scroll-px-[16px] gap-[16px] overflow-x-auto px-[16px] scrollbar-hide md:scroll-px-[24px] md:gap-[24px] md:px-[24px] xl:scroll-px-[0px]"
+        className="flex snap-x snap-mandatory scroll-px-[16px] gap-[16px] overflow-x-auto px-[16px] scrollbar-hide md:scroll-px-[24px] md:gap-[24px] md:px-[24px] xl:scroll-px-[0px] xl:px-[0px]"
       >
         {activitiesData.activities.map((activity) => (
           <ActivityCard key={activity.id} activity={activity} isBest />

--- a/src/components/organisms/nav-list/FilteredNavList.tsx
+++ b/src/components/organisms/nav-list/FilteredNavList.tsx
@@ -1,7 +1,13 @@
 import Button from '@/components/atoms/button/Button';
+import { ActivityCategory } from '@/types/activity';
 
-export default function FilteredNavList() {
+interface Props {
+  currentCategory: ActivityCategory;
+}
+
+export default function FilteredNavList({ currentCategory }: Props) {
   const categoryList = ['문화 · 예술', '식음료', '스포츠', '투어', '관광', '웰빙'];
+
   return (
     <ul className="flex gap-[24px]">
       {categoryList.map((category) => (
@@ -9,7 +15,7 @@ export default function FilteredNavList() {
           <Button
             text={category}
             color="white"
-            className="w-127pxr !rounded-[15px] py-[14px]"
+            className={`w-127pxr !rounded-[15px] !border-var-green-dark py-[14px] !font-[500] ${currentCategory === category ? '!bg-var-green-dark !text-white' : '!text-var-green-dark'}`}
             link={`/?category=${category}`}
           />
         </li>

--- a/src/components/organisms/nav-list/FilteredNavList.tsx
+++ b/src/components/organisms/nav-list/FilteredNavList.tsx
@@ -9,13 +9,13 @@ export default function FilteredNavList({ currentCategory }: Props) {
   const categoryList = ['문화 · 예술', '식음료', '스포츠', '투어', '관광', '웰빙'];
 
   return (
-    <ul className="flex gap-[24px]">
+    <ul className="relative flex w-full gap-[8px] overflow-x-auto scrollbar-hide md:gap-[16px] lg:gap-[24px]">
       {categoryList.map((category) => (
         <li key={category}>
           <Button
             text={category}
             color="white"
-            className={`w-127pxr !rounded-[15px] !border-var-green-dark py-[14px] !font-[500] ${currentCategory === category ? '!bg-var-green-dark !text-white' : '!text-var-green-dark'}`}
+            className={`w-80pxr !rounded-[15px] !border-var-green-dark py-[8px] !font-[500] md:w-120pxr md:py-[14px] lg:w-127pxr ${currentCategory === category ? '!bg-var-green-dark !text-white' : '!text-var-green-dark'}`}
             link={`/?category=${category}`}
           />
         </li>

--- a/src/components/templates/main/BestActivities.tsx
+++ b/src/components/templates/main/BestActivities.tsx
@@ -84,7 +84,7 @@ export default function BestActivities({ activitiesData }: Props) {
                 width={44}
                 height={44}
                 alt={arrow.name}
-                className={arrow.style}
+                className={`no-drag ${arrow.style}`}
               />
             </button>
           ))}

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -27,19 +27,19 @@ export default async function FilteredActivities({ searchParams }: Props) {
   };
 
   return (
-    <InnerLayout className="mb-[342px] mt-[60px]">
-      <div className="flex justify-between">
+    <InnerLayout className="mb-[200px] mt-[40px] md:mb-[342px] md:mt-[60px]">
+      <div className="flex justify-between gap-[10px]">
         <FilteredNavList currentCategory={searchParams.category} />
-        <DropdownMenu text="가격" className="!w-127pxr">
-          <Link className="w-full" href={addSearchParam({ sort: 'price_asc' })}>
+        <DropdownMenu text="가격" className="w-90pxr shrink-0 md:!w-127pxr">
+          <Link className="w-full" href={addSearchParam({ sort: 'price_asc' })} scroll={false}>
             가격이 낮은 순
           </Link>
-          <Link className="w-full" href={addSearchParam({ sort: 'price_desc' })}>
+          <Link className="w-full" href={addSearchParam({ sort: 'price_desc' })} scroll={false}>
             가격이 높은 순
           </Link>
         </DropdownMenu>
       </div>
-      <h2 className="mt-[40px] text-36pxr font-[700]">
+      <h2 className="mt-[22px] text-18pxr font-[700] md:mt-[40px] md:text-36pxr">
         {searchParams.category ? searchParams.category : '🛼 모든 체험'}
       </h2>
       <ActivityCardList activityList={activities} />

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -49,7 +49,6 @@ export default async function FilteredActivities({ searchParams }: Props) {
         <div className="mt-[30px] text-center">게시물이 없습니다.</div>
       ) : (
         <div className="mt-[72px] flex justify-center">
-          {/* <ReviewPagination totalPage={(totalCount + 8) / 8} currentPage={1} activityId={1} /> */}
           <Pagination totalCount={totalCount} currentPage={searchParams.page} />
         </div>
       )}

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -1,5 +1,6 @@
 import InnerLayout from '@/components/atoms/inner-layout/InnerLayout';
 import DropdownMenu from '@/components/molecules/dropdown-menu/DropdownMenu';
+import Pagination from '@/components/molecules/pagination/Pagination';
 import ActivityCardList from '@/components/organisms/card-list/ActivityCardList';
 import FilteredNavList from '@/components/organisms/nav-list/FilteredNavList';
 import ReviewPagination from '@/components/organisms/review-pagination/ReviewPagination';
@@ -10,15 +11,16 @@ import Link from 'next/link';
 import React from 'react';
 
 interface Props {
-  searchParams: { category: ActivityCategory; sort: ActivitySort };
+  searchParams: { category: ActivityCategory; sort: ActivitySort; page: number };
 }
 
 export default async function FilteredActivities({ searchParams }: Props) {
-  const { activities } = await getActivities({
+  const { activities, totalCount } = await getActivities({
     method: 'offset',
     size: 8,
     category: searchParams.category,
     sort: searchParams.sort ? searchParams.sort : 'latest',
+    page: searchParams.page ? searchParams.page : 1,
   });
 
   const addSearchParam = (param: {}) => {
@@ -43,9 +45,14 @@ export default async function FilteredActivities({ searchParams }: Props) {
         {searchParams.category ? searchParams.category : '🛼 모든 체험'}
       </h2>
       <ActivityCardList activityList={activities} />
-      <div className="mt-[72px] flex justify-center">
-        <ReviewPagination totalPage={1} currentPage={1} activityId={1} />
-      </div>
+      {!totalCount ? (
+        <div className="mt-[30px] text-center">게시물이 없습니다.</div>
+      ) : (
+        <div className="mt-[72px] flex justify-center">
+          {/* <ReviewPagination totalPage={(totalCount + 8) / 8} currentPage={1} activityId={1} /> */}
+          <Pagination totalCount={totalCount} currentPage={searchParams.page} />
+        </div>
+      )}
     </InnerLayout>
   );
 }

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -28,7 +28,9 @@ export default async function FilteredActivities({ searchParams }: Props) {
           <button className="w-full">가격이 높은 순</button>
         </DropdownMenu>
       </div>
-      <h2 className="mt-[40px] text-36pxr font-[700]">🛼 모든 체험</h2>
+      <h2 className="mt-[40px] text-36pxr font-[700]">
+        {searchParams.category ? searchParams.category : '🛼 모든 체험'}
+      </h2>
       <ActivityCardList activityList={activities} />
       <div className="mt-[72px] flex justify-center">
         <ReviewPagination totalPage={1} currentPage={1} activityId={1} />

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -3,29 +3,40 @@ import DropdownMenu from '@/components/molecules/dropdown-menu/DropdownMenu';
 import ActivityCardList from '@/components/organisms/card-list/ActivityCardList';
 import FilteredNavList from '@/components/organisms/nav-list/FilteredNavList';
 import ReviewPagination from '@/components/organisms/review-pagination/ReviewPagination';
+import makeQueryString from '@/lib/query-string';
 import { getActivities } from '@/queries/activities/get-activities';
-import { ActivityCategory } from '@/types/activity';
+import { ActivityCategory, ActivitySort } from '@/types/activity';
+import Link from 'next/link';
 import React from 'react';
 
 interface Props {
-  searchParams: { category: ActivityCategory };
+  searchParams: { category: ActivityCategory; sort: ActivitySort };
 }
 
 export default async function FilteredActivities({ searchParams }: Props) {
   const { activities } = await getActivities({
     method: 'offset',
-    sort: 'latest',
     size: 8,
     category: searchParams.category,
+    sort: searchParams.sort ? searchParams.sort : 'latest',
   });
+
+  const addSearchParam = (param: {}) => {
+    const newParams = Object.assign(searchParams, param);
+    return makeQueryString(newParams);
+  };
 
   return (
     <InnerLayout className="mb-[342px] mt-[60px]">
       <div className="flex justify-between">
         <FilteredNavList currentCategory={searchParams.category} />
         <DropdownMenu text="가격" className="!w-127pxr">
-          <button className="w-full">가격이 낮은 순</button>
-          <button className="w-full">가격이 높은 순</button>
+          <Link className="w-full" href={addSearchParam({ sort: 'price_asc' })}>
+            가격이 낮은 순
+          </Link>
+          <Link className="w-full" href={addSearchParam({ sort: 'price_desc' })}>
+            가격이 높은 순
+          </Link>
         </DropdownMenu>
       </div>
       <h2 className="mt-[40px] text-36pxr font-[700]">

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -22,7 +22,7 @@ export default async function FilteredActivities({ searchParams }: Props) {
   return (
     <InnerLayout className="mb-[342px] mt-[60px]">
       <div className="flex justify-between">
-        <FilteredNavList />
+        <FilteredNavList currentCategory={searchParams.category} />
         <DropdownMenu text="가격" className="!w-127pxr">
           <button className="w-full">가격이 낮은 순</button>
           <button className="w-full">가격이 높은 순</button>

--- a/src/components/templates/main/FilteredActivities.tsx
+++ b/src/components/templates/main/FilteredActivities.tsx
@@ -3,7 +3,6 @@ import DropdownMenu from '@/components/molecules/dropdown-menu/DropdownMenu';
 import Pagination from '@/components/molecules/pagination/Pagination';
 import ActivityCardList from '@/components/organisms/card-list/ActivityCardList';
 import FilteredNavList from '@/components/organisms/nav-list/FilteredNavList';
-import ReviewPagination from '@/components/organisms/review-pagination/ReviewPagination';
 import makeQueryString from '@/lib/query-string';
 import { getActivities } from '@/queries/activities/get-activities';
 import { ActivityCategory, ActivitySort } from '@/types/activity';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -98,9 +98,11 @@ const config = {
         },
       },
       screens: {
-        md: { min: '450px' },
-        lg: { min: '1024px' },
-        xl: { min: '1245px' },
+        // * Default: 모바일
+        md: { min: '450px' }, // * 테블릿
+        md2: { min: '750px' }, // (테블릿과 PC 사이)
+        lg: { min: '1024px' }, // * PC
+        xl: { min: '1245px' }, // (innerLayout 내부로 들어왔을 때)
       },
       inset: {
         unset: 'unset',
@@ -115,6 +117,7 @@ const config = {
     require('tailwind-scrollbar-hide'),
     function ({ addUtilities }: PluginAPI) {
       addUtilities({
+        // 이미지 드래그 막기
         '.no-drag': {
           '-webkit-user-drag': 'none' /* Chrome, Safari, Opera */,
           '-khtml-user-drag': 'none' /* Konqueror */,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import { PluginAPI } from 'tailwindcss/types/config';
 
 const pxToRem = (px: number, base = 16) => `${px / base}rem`;
 
@@ -109,7 +110,21 @@ const config = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate'), require('tailwind-scrollbar-hide')],
+  plugins: [
+    require('tailwindcss-animate'),
+    require('tailwind-scrollbar-hide'),
+    function ({ addUtilities }: PluginAPI) {
+      addUtilities({
+        '.no-drag': {
+          '-webkit-user-drag': 'none' /* Chrome, Safari, Opera */,
+          '-khtml-user-drag': 'none' /* Konqueror */,
+          '-moz-user-drag': 'none' /* Firefox */,
+          '-ms-user-drag': 'none' /* Internet Explorer/Edge */,
+          'user-drag': 'none',
+        },
+      });
+    },
+  ],
 } satisfies Config;
 
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -114,7 +114,7 @@ const config = {
   },
   plugins: [
     require('tailwindcss-animate'),
-    require('tailwind-scrollbar-hide'),
+    require('tailwind-scrollbar-hide'), // 'scrollbar-hide'
     function ({ addUtilities }: PluginAPI) {
       addUtilities({
         // 이미지 드래그 막기


### PR DESCRIPTION
## 어떤 기능인가요?

메인페이지 필터링 api 구현, 반응형 UI

## 작업 상세 내용

- [x] 필터링 (카테고리, 가격순) api 연결 
- [x] 반응형 UI 완료

- [ ] 검색기능 구현 예정
- [ ] 추후 필터네브 반응형 구현 예정
*시간이 좀 걸릴 것 같아서 다른 부분 다 하고 진행하겠습니다!

[디자인시안]
<img width="700" alt="스크린샷 2024-07-19 오후 12 38 52" src="https://github.com/user-attachments/assets/f64bf0c9-f827-4a38-887f-45f04ad61c5f">
<br />
[현재 구현 상태]
<img width="700" alt="스크린샷 2024-07-19 오후 12 52 13" src="https://github.com/user-attachments/assets/41cdeb42-c144-4118-a869-3da3fb30ff40">

## 고민되거나 어려운 부분 (선택)

하단 카드리스트들이 디자인 시안에서는 pc에서는 8개, 테블릿에서는 9개, 모바일에서는 4개씩 보이는데,
api 호출에 size를 화면사이즈마다 바꾸려면 서버사이드랜더링을 하지 못해서 고민입니다.

일단 대안으로는 그냥 모두 8개씩 불러오고, 테블릿 버전도 8개씩 불러오는 방향으로 생각하고 있습니다.

<img width="598" alt="스크린샷 2024-07-19 오후 12 53 48" src="https://github.com/user-attachments/assets/35a9381d-4c65-413b-aaaf-dd203debd0d5">
