### PR TITLE
Feat: 비로그인시 예약폼 및 레이아웃

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -2,17 +2,17 @@ import InnerLayout from '@/components/atoms/inner-layout/InnerLayout';
 import SideNavigationMenu from '@/components/organisms/side-navigation-menu/SideNavigationMenu';
 import Footer from '@/components/templates/footer/Footer';
 import Header from '@/components/templates/header/Header';
+
 export default function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <InnerLayout>
-      <div className="flex py-[72px] md:gap-[16px] lg:gap-[24px]">
-        <SideNavigationMenu />
-        <div className="w-full">{children}</div>
-      </div>
-    </InnerLayout>
+    <div className="flex min-h-screen flex-col bg-var-gray8">
+      <Header />
+      {children}
+      <Footer />
+    </div>
   );
 }

--- a/src/components/molecules/log-in-cover/LogInCover.tsx
+++ b/src/components/molecules/log-in-cover/LogInCover.tsx
@@ -1,0 +1,12 @@
+import Button from '@/components/atoms/button/Button';
+import Link from 'next/link';
+
+export default function LogInCover() {
+  return (
+    <div className="fixed bottom-[0px] left-[0px] right-[0px] z-20 flex h-92pxr w-screen items-center justify-center bg-white bg-opacity-50 md:absolute md:left-[0px] md:top-[0px] md:h-full md:w-full">
+      <Link href={'/signin'}>
+        <Button text="로그인 후 예약하기" color="black" className="p-[24px]" />
+      </Link>
+    </div>
+  );
+}

--- a/src/components/organisms/activity-reservation-form/ActivityReservationForm.tsx
+++ b/src/components/organisms/activity-reservation-form/ActivityReservationForm.tsx
@@ -39,7 +39,7 @@ export default function ActivityReservationForm({
     ? `${format(selectedSchedule.date, 'yy/MM/dd')} ${selectedSchedule.startTime} ~ ${selectedSchedule.endTime}`
     : '날짜 선택하기';
   return (
-    <div className="sticky top-[0px] h-fit">
+    <div className="h-fit">
       <div className="relative hidden h-fit w-250pxr shrink-0 flex-col rounded-[8px] border border-var-gray6 md:flex lg:hidden">
         <div className="flex items-center gap-[4px] p-[24px] pb-[16px]">
           <PriceDisplay price={price} fontSize={24} />

--- a/src/components/templates/activity-reservation-container/ActivityReservationContainer.tsx
+++ b/src/components/templates/activity-reservation-container/ActivityReservationContainer.tsx
@@ -8,6 +8,7 @@ import { ReservationFormProps } from '@/types/reservation-form-props';
 import useUser from '@/store/useUser';
 import postReservation from '@/queries/reservations/post-reservation';
 import { toast } from 'react-toastify';
+import LogInCover from '@/components/molecules/log-in-cover/LogInCover';
 interface Props extends ReservationFormProps {
   creatorId: number;
 }
@@ -20,13 +21,15 @@ export default function ActivityReservationContainer({
   creatorId,
 }: Props) {
   const { user } = useUser();
+  const isNotLoggedIn = !user;
   const isNotMyActivity = creatorId !== user?.id;
 
   return (
     <>
       {isNotMyActivity && (
         <ReservationProvider>
-          <>
+          <div className="relative h-fit">
+            {isNotLoggedIn && <LogInCover />}
             <ActivityReservationBar
               price={price}
               scheduleHash={scheduleHash}
@@ -45,7 +48,7 @@ export default function ActivityReservationContainer({
               scheduledDates={scheduledDates}
               activityId={activityId}
             />
-          </>
+          </div>
         </ReservationProvider>
       )}
     </>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,5 +10,5 @@ export function middleware(req: NextRequest) {
 
 // See "Matching Paths" below to learn more
 export const config = {
-  matcher: ['/activity/:path*', '/reservation'],
+  matcher: ['/reservation'],
 };


### PR DESCRIPTION
## 어떤 기능인가요?

- 로그인이 안됐을 경우 체험상세 페이지 접속시 예약폼 위에 로그인 버튼
- 레이아웃을 통해 헤더 푸터를 체험 상세페이지까지 적용

## 작업 상세 내용
- [x] 미들웨어 매쳐에서 체험상세 페이지 경로 제외
- [x] 레이아웃을 (main)에 적용 및 (protected) 레이아웃 수정
- [x] 로그인 여부 확인 후 미로그인시 예약폼 위에 로그인버튼 렌더링

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

![image](https://github.com/user-attachments/assets/f23b3df9-d937-4d1d-b25e-9fe381b2f230)
![image](https://github.com/user-attachments/assets/d8f5c02a-b4d9-4c8f-a440-a58c443b107f)
![image](https://github.com/user-attachments/assets/aa7196af-e57c-4adb-8a74-314c1574edd7)


## 고민되거나 어려운 부분 (선택)
디자인을 어떻게할지는 팀회의때 논의해보는게 좋을것같습니다
