### PR TITLE
Feat: add refetch button

### DIFF
--- a/src/components/templates/my-activity/Main.tsx
+++ b/src/components/templates/my-activity/Main.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { Activity, MyActivityList } from './../../../types/activity';
 import MyActivityCard from '@/components/molecules/activity-card/MyActivityCard';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getInstance } from '@/lib/axios';
 import LoadingSpinner from '@/components/atoms/loading-spinner/LoadingSpinner';
+import Button from '@/components/atoms/button/Button';
 
 const PAGE_SIZE = 10;
 
 export default function Main() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError, refetch } =
     useInfiniteQuery({
       queryKey: ['my-activities'],
       queryFn: ({ pageParam }: { pageParam: number | null }) => {
@@ -47,7 +48,13 @@ export default function Main() {
       </div>
     );
 
-  if (isError) return <div>error</div>;
+  if (isError)
+    return (
+      <div className="flex flex-col items-center">
+        <p>알 수 없는 이유로 체험 목록을 불러오지 못하였습니다.</p>
+        <Button className="px-10pxr" text="재시도" color="black" onClick={() => refetch()} />
+      </div>
+    );
 
   const firstDataCount = data?.pages[0].data.totalCount ?? 0;
   const height =

--- a/src/components/templates/reservation/Main.tsx
+++ b/src/components/templates/reservation/Main.tsx
@@ -3,11 +3,12 @@
 import ReservationCard from '@/components/molecules/reservation-card/ReservationCard';
 import { Reservation, ReservationStatus } from '@/types/reservation';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { getMyReservations } from '@/queries/reservations/get-my-reservations';
 import LoadingSpinner from '@/components/atoms/loading-spinner/LoadingSpinner';
 import { reservationsKeys } from './../../../queries/reservations/query-keys';
+import Button from '@/components/atoms/button/Button';
 
 const PAGE_SIZE = 10;
 
@@ -16,7 +17,7 @@ interface Props {
 }
 
 export default function Main({ status }: Props) {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError, refetch } =
     useInfiniteQuery({
       queryKey: reservationsKeys.getMyReservations(status),
       queryFn: ({ pageParam }: { pageParam: number | undefined }) => {
@@ -62,7 +63,13 @@ export default function Main({ status }: Props) {
       </div>
     );
 
-  if (isError) return <div>error</div>;
+  if (isError)
+    return (
+      <div className="flex flex-col items-center">
+        <p>알 수 없는 이유로 예약 내역을 불러오지 못하였습니다.</p>
+        <Button className="px-10pxr" text="재시도" color="black" onClick={() => refetch()} />
+      </div>
+    );
 
   const firstDataCount = data?.pages[0].totalCount ?? 0;
   const height =


### PR DESCRIPTION
## 어떤 기능인가요?

> 무한스크롤 페이지에서 데이터 호출 4번 재시도 후 isError가 true일 경우 나올 화면 생성

## 작업 상세 내용

- [x] 예약 내역 페이지 오류 메세지, 재시도 버튼 추가
- [x] 내 체험 관리 내역 페이지 오류 메세지, 재시도 버튼 추가

## 테스트 방법 (선택)

> 강제로 isError 대신 true 넣으시면 볼 수 있습니다.

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)
![image](https://github.com/user-attachments/assets/77cea3f6-32a9-4228-a9ab-0a2dbc0111d0)

## 고민되거나 어려운 부분 (선택)

> 글자 크기, 버튼 크기 맘대로 수정하셔도 됩니다.