### PR TITLE
refactor: 체험 등록/수정 제출 함수 변경 및 기타 스타일 수정

### DIFF
--- a/src/app/(main)/(protected)/layout.tsx
+++ b/src/app/(main)/(protected)/layout.tsx
@@ -1,7 +1,5 @@
 import InnerLayout from '@/components/atoms/inner-layout/InnerLayout';
 import SideNavigationMenu from '@/components/organisms/side-navigation-menu/SideNavigationMenu';
-import Footer from '@/components/templates/footer/Footer';
-import Header from '@/components/templates/header/Header';
 export default function Layout({
   children,
 }: Readonly<{

--- a/src/components/atoms/edit-profile-image/EditProfileImage.tsx
+++ b/src/components/atoms/edit-profile-image/EditProfileImage.tsx
@@ -12,7 +12,7 @@ export default function EditProfileImage() {
   return (
     <>
       <button
-        className="absolute bottom-[0px] right-[0] size-[30px] md:right-[12px] md:size-[44px]"
+        className="absolute bottom-[0px] right-[0] size-30pxr md:right-[12px] md:size-44pxr"
         onClick={() => openModal('editProfileImage')}
       >
         <Image fill src="/profile-image-setting-icon.svg" alt="프로필 사진 수정하기" />

--- a/src/components/molecules/address-input/AddressInput.tsx
+++ b/src/components/molecules/address-input/AddressInput.tsx
@@ -33,14 +33,6 @@ export default function AddressInput({ value, onChange }: Props) {
   const [detailAddress, setDetailAddress] = useState('');
 
   useEffect(() => {
-    if (value) {
-      const parts = value.split(' ');
-      if (parts.length > 0) setAddress(parts[0]);
-      if (parts.length > 1) setExtraAddress(parts.slice(1).join(' '));
-    }
-  }, [value]);
-
-  useEffect(() => {
     const fullAddress = ` ${address} ${extraAddress} ${detailAddress}`.trim();
     onChange(fullAddress);
   }, [address, extraAddress, detailAddress, onChange]);

--- a/src/components/molecules/modal/EditProfileModal.tsx
+++ b/src/components/molecules/modal/EditProfileModal.tsx
@@ -17,7 +17,7 @@ export default function EditProfileModal() {
   return (
     <Modal modalKey="editProfileImage">
       <div className="relative flex flex-col items-center justify-center gap-[48px] px-[50px] py-[24px] pb-[72px]">
-        <label className="flex flex-col gap-[24px] font-bold text-[48pxr]">
+        <label className="flex flex-col gap-[24px] text-48pxr font-bold">
           프로필 이미지 변경하기
           <div className="relative size-160pxr overflow-hidden rounded-full">
             {profileImage ? (

--- a/src/components/molecules/reservation-time-picker/ReservationTimePicker.tsx
+++ b/src/components/molecules/reservation-time-picker/ReservationTimePicker.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import TimeSlotList from './TimeSlotList';
 import { TimeSlotData } from '@/types/activity';
 import TimeSlotInput from '@/components/atoms/input/TimeSlotInput';
+import { useEffect, useRef } from 'react';
 
 interface Props {
   selectedDay: string;
@@ -13,6 +14,7 @@ interface Props {
   handleFormatDayClick: (day: Date) => void;
   setStartTime: React.Dispatch<React.SetStateAction<string>>;
   setEndTime: React.Dispatch<React.SetStateAction<string>>;
+  setIsCalendarOpen: React.Dispatch<React.SetStateAction<boolean>>;
   handleCalendarOpen: () => void;
   handleAddTimeSlot: () => void;
   handleDeleteTimeSlot: (date: string, startTime: string, endTime: string) => void;
@@ -26,6 +28,7 @@ export default function ReservationTimePicker({
   endTime,
   timeSlots,
   isCalendarOpen,
+  setIsCalendarOpen,
   handleFormatDayClick,
   handleCalendarOpen,
   handleAddTimeSlot,
@@ -33,6 +36,20 @@ export default function ReservationTimePicker({
   handleStartTimeChange,
   handleEndTimeChange,
 }: Props) {
+  const calendarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {
+        setIsCalendarOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [setIsCalendarOpen]);
+
   return (
     <div>
       <div className="relative flex place-items-end gap-[5px] border-b pb-[16px] md:h-[92px] lg:gap-[20px] lg:pb-[20px]">
@@ -49,7 +66,7 @@ export default function ReservationTimePicker({
             </button>
           </div>
           {isCalendarOpen && (
-            <div className="absolute top-[0px] top-full z-10 bg-white">
+            <div ref={calendarRef} className="absolute top-[0px] top-full z-10 bg-white">
               <Calendar onDayClick={(day) => handleFormatDayClick(day)} />
             </div>
           )}

--- a/src/components/organisms/activity-edit-form/ActivityEditForm.tsx
+++ b/src/components/organisms/activity-edit-form/ActivityEditForm.tsx
@@ -27,7 +27,6 @@ export default function ActivityEditForm({ initActivity }: Props) {
       methods.reset(initActivity);
     }
   }, [initActivity, methods]);
-  console.log(initActivity);
 
   const mutation = useMutation({
     ...patchMutationOptions,

--- a/src/components/organisms/activity-edit-form/ActivityEditForm.tsx
+++ b/src/components/organisms/activity-edit-form/ActivityEditForm.tsx
@@ -38,6 +38,9 @@ export default function ActivityEditForm({ initActivity }: Props) {
         exact: true,
       });
       router.refresh();
+      setTimeout(() => {
+        router.back();
+      }, 500);
     },
   });
 
@@ -45,7 +48,6 @@ export default function ActivityEditForm({ initActivity }: Props) {
     const body = editActivityForm(methods);
     if (body) {
       mutation.mutate({ activityId, body });
-      router.back();
     }
   };
 

--- a/src/components/organisms/activity-form/ActivityForm.tsx
+++ b/src/components/organisms/activity-form/ActivityForm.tsx
@@ -39,6 +39,7 @@ export default function ActivityForm({ initActivity }: Props) {
     deletedSchedule,
     setScheduleIds,
     isCalendarOpen,
+    setIsCalendarOpen,
     handleCalendarOpen,
     handleFormatDayClick,
     handleAddSchedules,
@@ -182,6 +183,7 @@ export default function ActivityForm({ initActivity }: Props) {
           endTime={endTime}
           timeSlots={schedules}
           isCalendarOpen={isCalendarOpen}
+          setIsCalendarOpen={setIsCalendarOpen}
           handleFormatDayClick={handleFormatDayClick}
           setStartTime={setStartTime}
           setEndTime={setEndTime}

--- a/src/components/organisms/activity-registration-form/ActivityRegistrationForm.tsx
+++ b/src/components/organisms/activity-registration-form/ActivityRegistrationForm.tsx
@@ -35,6 +35,9 @@ export default function ActivityRegistrationForm() {
         exact: true,
       });
       router.refresh();
+      setTimeout(() => {
+        router.back();
+      }, 500);
     },
   });
 
@@ -42,7 +45,6 @@ export default function ActivityRegistrationForm() {
     const body = registerActivityForm(methods);
     if (body) {
       mutation.mutate(body);
-      router.back();
     }
   };
 

--- a/src/components/organisms/hambuger-menu/HamburgerMenuItem.tsx
+++ b/src/components/organisms/hambuger-menu/HamburgerMenuItem.tsx
@@ -58,7 +58,7 @@ export default function HamburgerMenuItem({ isActive, setIsActive }: Props) {
       {user && (
         <div className="flex justify-end p-[16px]">
           <button
-            className="rounded-[12px] px-[16px] py-[8px] font-bold text-[16pxr] text-var-gray3"
+            className="rounded-[12px] px-[16px] py-[8px] text-16pxr font-bold text-var-gray3"
             onClick={handleLogout}
           >
             로그아웃

--- a/src/components/organisms/side-navigation-menu/SideNavigationMenu.tsx
+++ b/src/components/organisms/side-navigation-menu/SideNavigationMenu.tsx
@@ -28,7 +28,7 @@ export default function SideNavigationMenu() {
                 onMouseEnter={() => setHoveredItem(item.text)}
                 onMouseLeave={() => setHoveredItem(null)}
               >
-                <div className="relative size-[24px]">
+                <div className="relative size-24pxr">
                   <Image
                     fill
                     src={

--- a/src/models/activity/use-time-slot.ts
+++ b/src/models/activity/use-time-slot.ts
@@ -115,6 +115,7 @@ const useTimeSlot = () => {
     scheduleIds,
     setScheduleIds,
     isCalendarOpen,
+    setIsCalendarOpen,
     handleCalendarOpen,
     handleFormatDayClick,
     handleAddSchedules,


### PR DESCRIPTION
## 어떤 기능인가요?

 체험 등록/수정 제출 함수 변경 및 기타 스타일 수정

## 작업 상세 내용

- [x] 체험 등록/수정 제출 함수 변경
- [x] 기타 스타일 수정

## 고민되거나 어려운 부분 (선택)

<img width="1162" alt="스크린샷 2024-08-02 오후 12 07 34" src="https://github.com/user-attachments/assets/b9e91983-f43e-4e2e-a34c-9c5a61d1b3dd">

현재 비밀번호 확인 이전에도 프로필사진을 변경할 수 있는데 프로필 변경 버튼을 내 정보 수정 폼으로 옮기는건 어떨까요? 다른 분들 의견이 궁금합니다

