### PR TITLE
Refactor: 알림, 내 정보 페이지 쪽 UI 수정

### DIFF
--- a/src/app/(main)/(protected)/layout.tsx
+++ b/src/app/(main)/(protected)/layout.tsx
@@ -1,7 +1,5 @@
 import InnerLayout from '@/components/atoms/inner-layout/InnerLayout';
 import SideNavigationMenu from '@/components/organisms/side-navigation-menu/SideNavigationMenu';
-import Footer from '@/components/templates/footer/Footer';
-import Header from '@/components/templates/header/Header';
 export default function Layout({
   children,
 }: Readonly<{
@@ -9,7 +7,7 @@ export default function Layout({
 }>) {
   return (
     <InnerLayout>
-      <div className="flex py-[72px] md:gap-[16px] lg:gap-[24px]">
+      <div className="flex py-[24px] md:gap-[16px] md:py-[72px] lg:gap-[24px]">
         <SideNavigationMenu />
         <div className="w-full">{children}</div>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
         <Script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js" />
         <Providers>
           <ToastProvider>{children}</ToastProvider>
-          <ReactQueryDevtools initialIsOpen={false} />
+          {/* <ReactQueryDevtools initialIsOpen={false} /> */}
         </Providers>
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import './globals.css';
 import Providers from './react-query-providers';
 import ToastProvider from './ToastProvider';
 import Script from 'next/script';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import ScrollTopButton from '@/components/atoms/button/ScrollTopButton';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -44,6 +44,7 @@ export default function RootLayout({
           <ToastProvider>{children}</ToastProvider>
           {/* <ReactQueryDevtools initialIsOpen={false} /> */}
         </Providers>
+        <ScrollTopButton />
       </body>
     </html>
   );

--- a/src/components/atoms/button/NotificationButton.tsx
+++ b/src/components/atoms/button/NotificationButton.tsx
@@ -5,13 +5,14 @@ import { useNotification } from '@/models/header/notification-context';
 import { useGetMyNotifications } from '@/queries/my-notifications/get-my-notifications';
 import { useModal } from '@/store/useModal';
 import Image from 'next/image';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const PAGE_SIZE = 5;
 
 export default function NotificationButton() {
   const { isOpen, setIsOpen, setIsClose } = useModal();
   const { totalCount, setTotalCount, setNotificationList } = useNotification();
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const { data: notificationResponse, isLoading, fetchNextPage } = useGetMyNotifications(PAGE_SIZE);
 
@@ -32,10 +33,10 @@ export default function NotificationButton() {
 
   return (
     <>
-      <button onClick={handleClick} className="relative">
+      <button ref={buttonRef} onClick={handleClick} className="relative">
         <Image src="/bell.svg" alt="알림" width={20} height={20} />
         {!!totalCount && (
-          <div className="text-7pxr absolute right-[-2px] top-[0px] size-10pxr rounded-[50%] bg-var-red-dark text-white">
+          <div className="absolute right-[-2px] top-[0px] size-10pxr rounded-[50%] bg-var-red-dark text-7pxr text-white">
             {totalCount > 9 ? '+9' : totalCount}
           </div>
         )}
@@ -45,6 +46,7 @@ export default function NotificationButton() {
           modalKey="notification"
           isLoading={isLoading}
           fetchNextPage={fetchNextPage}
+          buttonRef={buttonRef}
         />
       )}
     </>

--- a/src/components/atoms/button/ScrollTopButton.tsx
+++ b/src/components/atoms/button/ScrollTopButton.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+
+export default function ScrollTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // 스크롤 이벤트 핸들러
+  const toggleVisibility = () => {
+    if (window.scrollY > 100) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  // 버튼 클릭 핸들러
+  const handleScrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', toggleVisibility);
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      onClick={handleScrollToTop}
+      className="fixed bottom-[16px] right-[16px] z-[99] flex size-40pxr items-center justify-center rounded-full border border-var-gray3 bg-white pb-[2px] transition-all duration-100 hover:shadow-hover md:bottom-[30px] md:right-[24px]"
+    >
+      <Image
+        src="/arrow-right.svg"
+        width={30}
+        height={30}
+        alt="스크롤 위로"
+        className="-rotate-90"
+      />
+    </button>
+  );
+}

--- a/src/components/atoms/loading-spinner/LoadingSpinner.tsx
+++ b/src/components/atoms/loading-spinner/LoadingSpinner.tsx
@@ -1,7 +1,7 @@
 export default function LoadingSpinner() {
   const style = 'size-10pxr animate-loading rounded-full bg-var-black';
   return (
-    <div className="space-x-2 flex items-center justify-center gap-[10px]">
+    <div className="space-x-2 flex items-center justify-center gap-[10px] py-[20px]">
       <div className={style}></div>
       <div className={`delay-100 ${style}`}></div>
       <div className={`delay-200 ${style}`}></div>

--- a/src/components/atoms/loading-spinner/LoadingSpinner.tsx
+++ b/src/components/atoms/loading-spinner/LoadingSpinner.tsx
@@ -1,13 +1,10 @@
-import Image from 'next/image';
-
 export default function LoadingSpinner() {
+  const style = 'size-10pxr animate-loading rounded-full bg-var-black';
   return (
-    <Image
-      src="/spinner.png"
-      alt="Loading..."
-      className="animate-spin-slow"
-      width={100}
-      height={100}
-    />
+    <div className="space-x-2 flex items-center justify-center gap-[10px]">
+      <div className={style}></div>
+      <div className={`delay-100 ${style}`}></div>
+      <div className={`delay-200 ${style}`}></div>
+    </div>
   );
 }

--- a/src/components/molecules/my-page-profile/MyPageProfile.tsx
+++ b/src/components/molecules/my-page-profile/MyPageProfile.tsx
@@ -8,14 +8,14 @@ export default function MyPageProfile() {
   const pathname = usePathname();
 
   return (
-    <div className="relative flex items-center justify-center md:pb-[24px]">
+    <div className="relative flex items-center justify-center md2:pb-[24px]">
       <div className="relative">
         {user && user.profileImageUrl ? (
-          <div className="relative size-80pxr overflow-hidden rounded-full md:size-160pxr">
+          <div className="relative size-80pxr overflow-hidden rounded-full md2:size-160pxr">
             <Image fill src={user.profileImageUrl} alt="프로필 사진" />
           </div>
         ) : (
-          <div className="flex size-80pxr items-center justify-center rounded-[50%] bg-var-gray1 text-40pxr text-white md:size-160pxr md:text-80pxr">
+          <div className="flex size-80pxr items-center justify-center rounded-[50%] bg-var-gray1 text-40pxr text-white md2:size-160pxr md2:text-80pxr">
             {user && user.nickname.slice(0, 1)}
           </div>
         )}

--- a/src/components/molecules/profile/HeaderProfile.tsx
+++ b/src/components/molecules/profile/HeaderProfile.tsx
@@ -20,9 +20,8 @@ export default function HeaderProfile({ nickname, imageUrl }: Props) {
   const { clearUser } = useUser();
 
   const listStyle =
-    'w-full text-start text-14pxr block py-[13px] px-[16px]  hover:bg-var-green2 hover:text-var-green-dark hover:font-[500]';
+    'w-full text-start text-14pxr block py-[13px] px-[16px] hover:bg-var-green2 hover:text-var-green-dark hover:font-[500]';
 
-  /** 로그아웃 로직 */
   const handleLogout = async () => {
     deleteCookie('userId');
     clearUser();

--- a/src/components/molecules/reservation-card/ReservationCard.tsx
+++ b/src/components/molecules/reservation-card/ReservationCard.tsx
@@ -36,7 +36,7 @@ export default function ReservationCard({
   return (
     <div className="flex h-full min-h-128pxr rounded-[24px] bg-white md:min-h-156pxr lg:min-h-204pxr">
       <CardImage variant="card" src={activity.bannerImageUrl} />
-      <div className="flex w-full flex-col justify-center py-9pxr pl-8pxr shadow-custom md:py-[12px] md:pl-[12px] md:pr-[18px] lg:px-[24px] lg:py-[25.5px]">
+      <div className="flex w-full flex-col justify-center gap-[5px] px-[8px] py-[9px] shadow-custom md:py-[12px] md:pl-[12px] md:pr-[18px] lg:px-[24px] lg:py-[25.5px]">
         <div
           className={`${RESERVATION_COLORS[status]} text-14pxr font-bold md:text-16pxr md:leading-26pxr lg:mb-8pxr`}
         >
@@ -54,7 +54,7 @@ export default function ReservationCard({
             <Button
               text="예약 취소"
               color="white"
-              className="h-32pxr w-80pxr md:h-40pxr md:w-112pxr lg:w-144pxr"
+              className="h-32pxr w-80pxr text-14pxr md:h-40pxr md:w-112pxr md:text-16pxr lg:w-144pxr"
               onClick={() => {
                 mutation.mutate({ reservationId: id });
               }}
@@ -66,7 +66,7 @@ export default function ReservationCard({
                 text={reviewSubmitted ? '후기 작성 완료' : '후기 작성'}
                 color="black"
                 disabled={reviewSubmitted}
-                className="h-32pxr w-80pxr md:h-40pxr md:w-112pxr lg:w-144pxr"
+                className="w-90pxr p-[3px] text-14pxr md:h-40pxr md:w-112pxr md:p-[8px] md:text-16pxr lg:w-144pxr"
                 onClick={() => {
                   setIsOpen(`editReviewModal-${id}`);
                 }}

--- a/src/components/organisms/hambuger-menu/HamburgerMenu.tsx
+++ b/src/components/organisms/hambuger-menu/HamburgerMenu.tsx
@@ -46,7 +46,7 @@ export default function HamburgerMenu() {
         ))}
       </button>
       <div
-        className={`absolute left-[0px] top-[43px] flex h-[calc(100vh-43px)] w-[100vw] list-none flex-col bg-white ${isActive ? 'block' : 'hidden'}`}
+        className={`absolute left-[0px] top-[43px] flex h-[calc(100vh-43px)] w-[100vw] list-none flex-col bg-white md:top-[66px] md:h-[calc(100vh-66px)] ${isActive ? 'block' : 'hidden'}`}
       >
         {user ? (
           <div className="flex items-center gap-[20px] bg-var-gray6 px-[24px] py-[20px]">

--- a/src/components/organisms/my-page-form/PasswordCheckForm.tsx
+++ b/src/components/organisms/my-page-form/PasswordCheckForm.tsx
@@ -45,28 +45,36 @@ export default function PasswordCheckForm({ setPassword }: Props) {
 
   return (
     <form onSubmit={handleSubmit(submit)}>
-      <div className="mb-24pxr flex h-48pxr items-start justify-between overflow-hidden text-ellipsis">
-        <h1 className="text-32pxr font-bold">내 정보 - 비밀번호 확인</h1>
-        <Button className="h-48pxr w-120pxr" type="submit" text="확인" color="black" />
-      </div>
-      <Controller
-        control={control}
-        name="password"
-        rules={{ required: '비밀번호를 입력해 주세요.' }}
-        render={({ field }) => (
-          <div>
-            <PasswordInput
-              size="full"
-              label="비밀번호 확인"
-              hasError={errors.password !== undefined}
-              {...field}
-            />
-            {errors.password && (
-              <div className={FORM_OPTIONS.errorMsgStyle}>{errors.password.message}</div>
+      <h1 className="mb-[24px] text-center text-32pxr font-bold md:text-start">비밀번호 확인</h1>
+      <div className="flex h-360pxr flex-col items-center justify-center gap-[10px] rounded-[10px] bg-white px-[20px] shadow-md">
+        <p className="text-center">회원정보 수정을 위한 비밀번호 확인 절차입니다.</p>
+        <div className="mt-[10px] flex w-full max-w-500pxr flex-col gap-[10px] md2:flex-row">
+          <Controller
+            control={control}
+            name="password"
+            rules={{ required: '비밀번호를 입력해 주세요.' }}
+            render={({ field }) => (
+              <div className="w-full grow">
+                <PasswordInput
+                  size="full"
+                  label=""
+                  hasError={errors.password !== undefined}
+                  {...field}
+                />
+                {errors.password && (
+                  <div className={FORM_OPTIONS.errorMsgStyle}>{errors.password.message}</div>
+                )}
+              </div>
             )}
-          </div>
-        )}
-      />
+          />
+          <Button
+            className="mb-[30px] h-54pxr w-full md2:mt-[16px] md2:w-150pxr"
+            type="submit"
+            text="확인"
+            color="black"
+          />
+        </div>
+      </div>
     </form>
   );
 }

--- a/src/components/organisms/notification-list/NotificationList.tsx
+++ b/src/components/organisms/notification-list/NotificationList.tsx
@@ -28,7 +28,7 @@ export default function NotificationList({ isLoading, fetchNextPage }: Props) {
 
   if (!notificationList?.length)
     return (
-      <div className="flex h-[calc(100vh-88px)] flex-col items-center justify-center gap-[10px] pb-[30px] md:h-fit">
+      <div className="flex h-[calc(100vh-88px)] flex-col items-center justify-center gap-[10px] pb-[20px] md:h-fit">
         <Image src="/bell-nothing.svg" width={100} height={100} alt="알림 없음" />
         <p className="font-[500] text-var-gray9">아직 알림이 없습니다.</p>
       </div>

--- a/src/components/organisms/side-navigation-menu/SideNavigationMenu.tsx
+++ b/src/components/organisms/side-navigation-menu/SideNavigationMenu.tsx
@@ -16,7 +16,7 @@ export default function SideNavigationMenu() {
   const activeMenuStyle = 'text-var-green-dark bg-var-green2 rounded-[12px]';
 
   return (
-    <div className="hidden h-432pxr w-432pxr flex-col gap-[24px] rounded-xl bg-white p-[24px] shadow-md md:flex">
+    <div className="hidden h-432pxr w-432pxr flex-col gap-[24px] rounded-xl bg-white p-[24px] shadow-md md2:flex">
       <MyPageProfile />
       <nav className="mt-4">
         <ul>

--- a/src/components/templates/footer/Footer.tsx
+++ b/src/components/templates/footer/Footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
     <footer className="bg-[#121] pb-66pxr pt-32pxr">
       <InnerLayout>
         <div className="grid grid-cols-3 gap-y-24pxr md:grid-cols-4">
-          <div className="text-center text-[#676767]">©codeit - 2023</div>
+          <div className="text-center text-[#676767]">©codeit - 2024</div>
           <div className="text-right text-[#676767]">Privacy Policy</div>
           <div className="text-center text-[#676767]">FAQ</div>
           <div className="col-start-2 flex justify-center gap-x-12pxr md:col-start-4">

--- a/src/components/templates/header/Header.tsx
+++ b/src/components/templates/header/Header.tsx
@@ -47,10 +47,10 @@ export default function Header() {
                 <NotificationButton />
               </NotificationProvider>
               {/* 모바일사이즈에서 햄버거 메뉴 태블릿사이즈부터 프로필 */}
-              <div className="hidden md:flex">
+              <div className="hidden md2:flex">
                 <HeaderProfile nickname={user.nickname} imageUrl={user.profileImageUrl} />
               </div>
-              <div className="block md:hidden">
+              <div className="block md2:hidden">
                 <HamburgerMenu />
               </div>
             </div>

--- a/src/components/templates/header/NotificationModal.tsx
+++ b/src/components/templates/header/NotificationModal.tsx
@@ -2,23 +2,59 @@ import NotificationList from '@/components/organisms/notification-list/Notificat
 import { useNotification } from '@/models/header/notification-context';
 import { useModal } from '@/store/useModal';
 import Image from 'next/image';
+import { RefObject, useCallback, useEffect, useRef } from 'react';
 
 interface Props {
   modalKey: string;
   isLoading: boolean;
   fetchNextPage: () => void;
+  buttonRef: RefObject<HTMLButtonElement>;
 }
 
-export default function NotificationModal({ modalKey, isLoading, fetchNextPage }: Props) {
+export default function NotificationModal({
+  modalKey,
+  isLoading,
+  fetchNextPage,
+  buttonRef,
+}: Props) {
   const { key, isOpen, setIsClose } = useModal();
   const { totalCount } = useNotification();
+  const modalRef = useRef<HTMLDivElement>(null);
 
   const isSelected = key === modalKey;
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsClose();
+      }
+    },
+    [buttonRef, setIsClose],
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, handleClickOutside]);
 
   return (
     <>
       {isOpen && isSelected && (
-        <div className="fixed left-[0] top-[0] z-[80] flex w-full flex-col gap-[16px] border border-var-gray5 bg-var-green2 p-[20px] shadow-[0_2px_8px_0_rgba(120,116,134,0.25)] md:absolute md:left-unset md:right-[24px] md:top-[65px] md:w-[90%] md:max-w-368pxr md:rounded-[10px]">
+        <div
+          ref={modalRef}
+          className="fixed left-[0] top-[0] z-[80] flex w-full flex-col gap-[16px] border border-var-gray5 bg-var-green2 p-[20px] shadow-[0_2px_8px_0_rgba(120,116,134,0.25)] md:absolute md:left-unset md:right-[24px] md:top-[65px] md:w-[90%] md:max-w-368pxr md:rounded-[10px]"
+        >
           <div className="flex items-center justify-between">
             <h2 className="text-20pxr font-[700]">알림 {totalCount}개</h2>
             <button onClick={setIsClose}>

--- a/src/components/templates/my-activity/Main.tsx
+++ b/src/components/templates/my-activity/Main.tsx
@@ -73,7 +73,7 @@ export default function Main() {
       ))}
       {hasNextPage && !isFetchingNextPage && <div ref={ref} className="h-1pxr"></div>}
       {isFetchingNextPage && (
-        <div className="flex min-h-300pxr w-full justify-center">
+        <div className="flex w-full justify-center">
           <LoadingSpinner />
         </div>
       )}

--- a/src/components/templates/my-activity/Main.tsx
+++ b/src/components/templates/my-activity/Main.tsx
@@ -43,7 +43,7 @@ export default function Main() {
 
   if (isPending)
     return (
-      <div className="flex w-full justify-center">
+      <div className="flex min-h-300pxr w-full justify-center">
         <LoadingSpinner />
       </div>
     );
@@ -73,7 +73,7 @@ export default function Main() {
       ))}
       {hasNextPage && !isFetchingNextPage && <div ref={ref} className="h-1pxr"></div>}
       {isFetchingNextPage && (
-        <div className="flex w-full justify-center">
+        <div className="flex min-h-300pxr w-full justify-center">
           <LoadingSpinner />
         </div>
       )}

--- a/src/components/templates/reservation/Main.tsx
+++ b/src/components/templates/reservation/Main.tsx
@@ -84,7 +84,7 @@ export default function Main({ status }: Props) {
       ))}
       {hasNextPage && !isFetchingNextPage && <div ref={ref} className="h-1pxr"></div>}
       {isFetchingNextPage && (
-        <div className="flex min-h-300pxr w-full justify-center">
+        <div className="flex w-full justify-center">
           <LoadingSpinner />
         </div>
       )}

--- a/src/components/templates/reservation/Main.tsx
+++ b/src/components/templates/reservation/Main.tsx
@@ -58,7 +58,7 @@ export default function Main({ status }: Props) {
 
   if (isPending)
     return (
-      <div className="flex w-full justify-center">
+      <div className="flex min-h-300pxr w-full items-center justify-center">
         <LoadingSpinner />
       </div>
     );
@@ -84,7 +84,7 @@ export default function Main({ status }: Props) {
       ))}
       {hasNextPage && !isFetchingNextPage && <div ref={ref} className="h-1pxr"></div>}
       {isFetchingNextPage && (
-        <div className="flex w-full justify-center">
+        <div className="flex min-h-300pxr w-full justify-center">
           <LoadingSpinner />
         </div>
       )}

--- a/src/components/templates/reservation/Main.tsx
+++ b/src/components/templates/reservation/Main.tsx
@@ -3,7 +3,7 @@
 import ReservationCard from '@/components/molecules/reservation-card/ReservationCard';
 import { Reservation, ReservationStatus } from '@/types/reservation';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { getMyReservations } from '@/queries/reservations/get-my-reservations';
 import LoadingSpinner from '@/components/atoms/loading-spinner/LoadingSpinner';
@@ -71,12 +71,8 @@ export default function Main({ status }: Props) {
       </div>
     );
 
-  const firstDataCount = data?.pages[0].totalCount ?? 0;
-  const height =
-    firstDataCount > 3 ? 'h-1200pxr' : firstDataCount > 1 ? 'h-800pxr' : 'h-[calc(100vh-410px)]';
-
   return (
-    <div className={`${height} overflow-y-scroll scrollbar-hide`}>
+    <>
       {data?.pages.map((page, pageIndex) => (
         <div key={pageIndex}>
           {page.reservations.map((reservation: Reservation) => (
@@ -92,6 +88,6 @@ export default function Main({ status }: Props) {
           <LoadingSpinner />
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -119,12 +119,18 @@ const config = {
         all: '0 4px 8px 0px rgba(17, 34, 17, 0.4)',
       },
       animation: {
-        'spin-slow': 'spin 2s linear infinite',
+        loading: 'loading 1s infinite',
       },
       transitionDuration: {
         '3000': '3000ms',
         '5000': '5000ms',
         '7000': '7000ms',
+      },
+    },
+    keyframes: {
+      loading: {
+        '0%, 100%': { opacity: '0', transform: 'scale(0.5)' },
+        '50%': { opacity: '0.5', transform: 'scale(1.2)' },
       },
     },
   },


### PR DESCRIPTION
## 어떤 기능인가요?

알림, 내 정보 페이지 쪽 UI 수정

## 작업 상세 내용

- [x] 알림모달 외부 클릭해도 닫히도록 구현
- [x] 내 정보 페이지 들어갔을 때 비밀번호 확인 ui 수정
- [x] 내정보 쪽 md2 이하부터 사이드메뉴 사라지고 햄버거 버튼 보이도록 수정 및 기타 반응형 ui 수정
- [x] LoadingSpinner 컴포넌트 ui 수정
- [x] 예약내역 전체 스크롤로 수정
- [x] 화면 스크롤 시 상단 스크롤 버튼 보이도록 구현


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

[로딩스피너]

https://github.com/user-attachments/assets/c7773b43-d362-47d1-923d-5046972d3cb5



[상단 스크롤 버튼]

https://github.com/user-attachments/assets/c861e3c4-50e1-4df6-b6e2-26ad37d4f15c




